### PR TITLE
Git ignore yaml and png files in the root of a repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Gemfile.lock
 tmp
 coverage
+*.png
+*.yaml


### PR DESCRIPTION
When you have working directory pointed to root of the repo - that is very
convenient