### PR TITLE
Refactor Backup class

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -1,35 +1,34 @@
 class Backup
+  BACKUP_DIR = File.expand_path("~/.trollolo/backup")
 
+  attr_reader :board_id
   attr_accessor :directory
 
-  def initialize settings
+  def initialize(board_id, settings)
+    @board_id = board_id
     @settings = settings
-    @directory = File.expand_path("~/.trollolo/backup")
   end
 
-  def backup(board_id)
-    backup_path = File.join(@directory, board_id)
+  def self.list
+    Dir.entries(BACKUP_DIR).reject { |d| d =~ /^\./ }
+  end
+
+  def backup
     FileUtils.mkdir_p(backup_path)
 
     trello = TrelloWrapper.new(@settings)
 
     data = trello.backup(board_id)
 
-    File.open(File.join(backup_path, "board.json"), "w") do |f|
+    File.open(backup_file, "w") do |f|
       f.write(data)
     end
   end
 
-  def list
-    Dir.entries(@directory).reject { |d| d =~ /^\./ }
-  end
-
-  def show(board_id, options = {})
+  def show(options = {})
     out = options[:output] || STDOUT
 
-    backup_path = File.join(@directory, board_id)
-
-    board = JSON.parse(File.read(File.join(backup_path, "board.json")))
+    board = JSON.parse(File.read(backup_file))
 
     out.puts board["name"]
 
@@ -64,4 +63,13 @@ class Backup
     end
   end
 
+  private
+
+  def backup_path
+    File.join(BACKUP_DIR, board_id)
+  end
+
+  def backup_file
+    File.join(backup_path, "board.json")
+  end
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -202,14 +202,13 @@ EOT
     process_global_options options
     require_trello_credentials
 
-    b = Backup.new @@settings
-    b.backup(options["board-id"])
+    b = Backup.new(options["board-id"], @@settings)
+    b.backup
   end
 
   desc "list_backups", "List all backups"
   def list_backups
-    b = Backup.new @@settings
-    b.list.each do |backup|
+    Backup.list.each do |backup|
       puts backup
     end
   end
@@ -218,8 +217,8 @@ EOT
   option "board-id", :desc => "Id of Trello board", :required => true
   option "show-descriptions", :desc => "Show descriptions of cards", :required => false, :type => :boolean
   def show_backup
-    b = Backup.new @@settings
-    b.show(options["board-id"], options)
+    b = Backup.new(options["board-id"], @@settings)
+    b.show(options)
   end
 
   desc "organization", "Show organization info"

--- a/spec/unit/backup_spec.rb
+++ b/spec/unit/backup_spec.rb
@@ -4,36 +4,37 @@ include GivenFilesystemSpecHelpers
 
 describe Backup do
   it "sets backup directory" do
-    backup = Backup.new(dummy_settings)
-    expect(backup.directory).to match File.expand_path("~/.trollolo/backup")
+    _ = Backup.new("myboard", dummy_settings)
+    expect(Backup::BACKUP_DIR).to match File.expand_path("~/.trollolo/backup")
   end
 
-  context "custom backup directory" do
+  context "change backup directory for tests" do
     use_given_filesystem(keep_files: true)
 
     before(:each) do
       full_board_mock
-      @backup = Backup.new(dummy_settings)
-      @directory = given_directory
-      @backup.directory = @directory
+      Backup.send(:remove_const, 'BACKUP_DIR')
+      Backup::BACKUP_DIR = given_directory
+
+      @backup = Backup.new("53186e8391ef8671265eba9d", dummy_settings)
     end
 
     it "backups board" do
-      @backup.backup("53186e8391ef8671265eba9d")
-      backup_file = File.join(@directory, "53186e8391ef8671265eba9d", "board.json")
+      @backup.backup
+      backup_file = File.join(Backup::BACKUP_DIR, "53186e8391ef8671265eba9d", "board.json")
       expect(File.exist?(backup_file)).to be true
       expect(File.read(backup_file)).to eq load_test_file("full-board.json").chomp
     end
 
     it "lists backups" do
-      @backup.backup("53186e8391ef8671265eba9d")
-      expect(@backup.list).to eq ["53186e8391ef8671265eba9d"]
+      @backup.backup
+      expect(Backup.list).to eq ["53186e8391ef8671265eba9d"]
     end
 
     it "shows backup" do
       output_capturer = StringIO.new
-      @backup.backup("53186e8391ef8671265eba9d")
-      @backup.show("53186e8391ef8671265eba9d", output: output_capturer )
+      @backup.backup
+      @backup.show output: output_capturer
       expect(output_capturer.string).to eq(<<EOT
 Trollolo Testing Board
   Sprint Backlog


### PR DESCRIPTION
From my point of view, a `Backup` object should relate to the board it's been backed up. That's why I have included the board id as a parameter in the constructor (and thus as an instance variable). The backup directory was also changed to be a constant.

@cornelius I would appreciate your input here as well :)

Thanks!