### PR TITLE
Use board aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ To create a member token for the `set-priority` command use this URL instead:
 
 The board id is the cryptic string in the URL of your board.
 
+The `.trollolorc` file can also be used to set aliases for board ids. When set,
+you will be able to use the alias instead of the board-id in the various
+commands. E.g.
+
+With the following configuration
+
+```
+board_aliases:
+  MyTrelloBoard: 53186e8391ef8671265ebf9e
+
+```
+
+You can issue the command:
+
+```
+  trollolo get-cards --board-id=MyTrelloBoard
+```
+
 ## Creating burndown charts
 
 Trollolo implements a simple work flow for creating burndown charts from the

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -74,7 +74,7 @@ EOT
     require_trello_credentials
 
     trello = TrelloWrapper.new(@@settings)
-    board = trello.board(options["board-id"])
+    board = trello.board(board_id(options["board-id"]))
     lists = board.columns
 
     if @@settings.raw
@@ -93,7 +93,7 @@ EOT
     require_trello_credentials
 
     trello = TrelloWrapper.new(@@settings)
-    board = trello.board(options["board-id"])
+    board = trello.board(board_id(options["board-id"]))
     cards = board.cards
 
     if @@settings.raw
@@ -118,7 +118,7 @@ EOT
     require_trello_credentials
 
     trello = TrelloWrapper.new(@@settings)
-    board = trello.board(options["board-id"])
+    board = trello.board(board_id(options["board-id"]))
     board.cards.each do |card|
       card.checklists.each do |checklist|
         puts checklist.name
@@ -160,7 +160,7 @@ EOT
 
     chart = BurndownChart.new @@settings
     puts "Preparing directory..."
-    chart.setup(options[:output],options["board-id"])
+    chart.setup(options[:output],board_id(options["board-id"]))
   end
 
   desc "burndown", "Update burndown chart"
@@ -203,7 +203,7 @@ EOT
     require_trello_credentials
 
     b = Backup.new @@settings
-    b.backup(options["board-id"])
+    b.backup(board_id(options["board-id"]))
   end
 
   desc "list-backups", "List all backups"
@@ -219,7 +219,7 @@ EOT
   option "show-descriptions", :desc => "Show descriptions of cards", :required => false, :type => :boolean
   def show_backup
     b = Backup.new @@settings
-    b.show(options["board-id"], options)
+    b.show(board_id(options["board-id"]), options)
   end
 
   desc "organization", "Show organization info"
@@ -305,7 +305,7 @@ EOT
     require_trello_credentials
 
     p = Prioritizer.new(@@settings)
-    p.prioritize(options["board-id"], options["list-name"])
+    p.prioritize(board_id(options["board-id"]), options["list-name"])
   end
 
   desc "list-member-boards", "List name and id of all boards"
@@ -334,7 +334,8 @@ EOT
     require_trello_credentials
 
     s = SprintCleanup.new(@@settings)
-    s.cleanup(options["board-id"], options["target-board-id"])
+    s.cleanup(board_id(options["board-id"]),
+              board_id(options["target-board-id"]))
   end
 
   private
@@ -367,5 +368,12 @@ EOT
       STDERR.puts "Require trello credentials in config file"
       exit 1
     end
+  end
+
+  # Returns the board_id using id_or_alias. If id_or_alias matches a mapping
+  # from trollolorc then the mapped id is returned or else the id_or_alias
+  # is returned.
+  def board_id(id_or_alias)
+    @@settings.board_aliases[id_or_alias] || id_or_alias
   end
 end

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -17,9 +17,9 @@
 
 class Settings
 
-  attr_accessor :developer_public_key, :member_token, :verbose, :raw,
-                :not_done_columns, :todo_column, :done_column_name_regex,
-                :todo_column_name_regex
+  attr_accessor :developer_public_key, :member_token, :board_aliases, :verbose,
+                :raw, :not_done_columns, :todo_column,
+                :done_column_name_regex, :todo_column_name_regex
 
   def initialize config_file_path
     @config_file_path = config_file_path
@@ -29,6 +29,7 @@ class Settings
       if @config
         @developer_public_key   = @config["developer_public_key"]
         @member_token           = @config["member_token"]
+        @board_aliases          = @config["board_aliases"] || {}
         @not_done_columns       = @config["not_done_columns"].freeze || ["Sprint Backlog", "Doing"]
         @todo_column            = @config["todo_column"].freeze
         @done_column_name_regex = @config["done_column_name_regex"].freeze || /\ADone/

--- a/man/trollolo.1.md
+++ b/man/trollolo.1.md
@@ -23,7 +23,10 @@ and cards and has functionality for extracting data for burndown charts.
 
   * `--board-id`:
     Most commands take a `board-id` parameter. This is the id of the Trello
-    board. It is the cryptic part of the URL of the Trello board.
+    board. It is the cryptic part of the URL of the Trello board. Since the
+    actual id is hard to remember, you can set an alias in the `.trollolorc`
+    file and use that instead of the actual id.
+    See [CONFIGURATION](#CONFIGURATION) section below.
 
   * `--raw`:
     Some of the commands take a `raw` option. If this is provided the commands
@@ -125,6 +128,24 @@ For creating a member token go follow the
 in the Trello API documentation.
 
 The board id is the cryptic string in the URL of your board.
+
+The `.trollolorc` file can also be used to set aliases for board ids. When set,
+you will be able to use the alias instead of the board-id in the various
+commands. E.g.
+
+With the following configuration
+
+```
+board_aliases:
+  MyTrelloBoard: 53186e8391ef8671265ebf9e
+
+```
+
+You can issue the command:
+
+```
+  trollolo get-cards --board-id=MyTrelloBoard
+```
 
 
 ## CONVENTIONS FOR SCRUM BOARDS

--- a/spec/data/trollolorc_with_board_aliases
+++ b/spec/data/trollolorc_with_board_aliases
@@ -1,0 +1,9 @@
+developer_public_key: mykey
+member_token: mytoken
+not_done_columns:
+  - Blocked
+  - Doing
+  - In review
+  - Sprint Backlog
+board_aliases:
+  MyTrelloBoard: 53186e8391ef8671265eba9d

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -6,7 +6,8 @@ describe Cli do
   use_given_filesystem
 
   before(:each) do
-    Cli.settings = dummy_settings
+    Cli.settings = Settings.new(
+      File.expand_path('../../data/trollolorc_with_board_aliases', __FILE__))
     @cli = Cli.new
   end
 
@@ -26,6 +27,12 @@ describe Cli do
     @cli.backup
   end
 
+  it "backups board using an alias" do
+    expect_any_instance_of(Backup).to receive(:backup)
+    @cli.options = {"board-id" => "MyTrelloBoard"}
+    @cli.backup
+  end
+
   it "gets lists" do
     full_board_mock
     @cli.options = {"board-id" => "53186e8391ef8671265eba9d"}
@@ -37,6 +44,13 @@ Done Sprint 9
 Done Sprint 8
 Legend
 EOT
+    expect {
+      @cli.get_lists
+    }.to output(expected_output).to_stdout
+
+
+    # Using an alias
+    @cli.options = {"board-id" => "MyTrelloBoard"}
     expect {
       @cli.get_lists
     }.to output(expected_output).to_stdout
@@ -73,6 +87,12 @@ EOT
     expect {
       @cli.get_cards
     }.to output(expected_output).to_stdout
+
+    # Using an alias
+    @cli.options = {"board-id" => "MyTrelloBoard"}
+    expect {
+      @cli.get_cards
+    }.to output(expected_output).to_stdout
   end
 
   it "gets checklists" do
@@ -92,6 +112,12 @@ Tasks
 Tasks
 Tasks
 EOT
+    expect {
+      @cli.get_checklists
+    }.to output(expected_output).to_stdout
+
+    # Using an alias
+    @cli.options = {"board-id" => "MyTrelloBoard"}
     expect {
       @cli.get_checklists
     }.to output(expected_output).to_stdout
@@ -136,5 +162,21 @@ EOT
     @cli.options = {"card-id" => "54ae8485221b1cc5b173e713"}
     @cli.set_description
     expect(WebMock).to have_requested(:put, "https://api.trello.com/1/cards/54ae8485221b1cc5b173e713/desc?key=mykey&token=mytoken&value=My%20description")
+  end
+
+  context "#board_id" do
+    before do
+      Cli.settings = Settings.new(
+        File.expand_path('../../data/trollolorc_with_board_aliases', __FILE__))
+      @cli = Cli.new
+    end
+
+    it "returns the id when no alias exists" do
+      expect(@cli.send(:board_id, "1234")).to eq("1234")
+    end
+
+    it "return the id when an alias exists" do
+      expect(@cli.send(:board_id, "MyTrelloBoard")).to eq("53186e8391ef8671265eba9d")
+    end
   end
 end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -12,10 +12,28 @@ describe Settings do
     it "is not verbose by default" do
       expect(@settings.verbose).to be false
     end
-    
+
     it "reads config file" do
       expect(@settings.developer_public_key).to eq "mykey"
       expect(@settings.member_token).to eq "mytoken"
+    end
+
+    context "#board_aliases" do
+      context "when aliases do not exist" do
+        it "returns an empty Hash" do
+          expect(@settings.board_aliases).to eq({})
+        end
+      end
+
+      context "when mapping exists" do
+        before do
+          @settings = Settings.new( File.expand_path('../../data/trollolorc_with_board_aliases',__FILE__) )
+        end
+
+        it "returns the mapping" do
+          expect(@settings.board_aliases).to eq({"MyTrelloBoard" => "53186e8391ef8671265eba9d"})
+        end
+      end
     end
   end
   


### PR DESCRIPTION
With board aliases defined in `trollolorc` file, the users will be able to use "easy" names instead of actual ids for the various commands (for --board-id option).