### PR TITLE
fix done_column method

### DIFF
--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -191,6 +191,7 @@ class BurndownChart
 
   def update(options)
     burndown_data_path = load_last_sprint(options['output'] || Dir.pwd)
+    $sprint_nr = self.sprint
 
     burndown_data = BurndownData.new(@settings)
     burndown_data.board_id = board_id

--- a/lib/scrum_board.rb
+++ b/lib/scrum_board.rb
@@ -17,8 +17,12 @@ class ScrumBoard
       done_columns = columns.select{|c| c.name =~ @settings.done_column_name_regex }
       if done_columns.empty?
         raise DoneColumnNotFoundError, "can't find done column by name regex #{@settings.done_column_name_regex}"
+      end
+      current_numbered_done_column = done_columns.find { |c| c.name.include? $sprint_nr.to_s }
+      if current_numbered_done_column
+        current_numbered_done_column
       else
-        done_columns.max_by{|c| c.name.match(@settings.done_column_name_regex).captures.first.to_i }
+        done_columns.first
       end
     end
   end


### PR DESCRIPTION
The current method is broken as it always returns the "Done [...]" column that appears first on the board.

The `max_by [number]` thing is not working with that regexp. It matches nothing and therefore, sorting by the capture means sorting two nils, which returns the first.
Actually this broken state was a good thing for us as it allowed us to work around the actual problem:
The done_column method should _not_ return the one with the highest number!

**Some explanation**
We in SCC always number our Done columns like "Done Sprint 44", "Done Sprint 45", ...
After the Review meeting of sprint 44, we already create the column for sprint 45, so people can move done cards there (as the old sprint is officially finished).
When _trollolo_ then does its thing in the evening, it confuses the two columns and reads wrong data.
It should check the sprint 44 column one last time and not take the data from sprint 45 column and store it as part of sprint 44 in the yaml.
Our workaround currently is to move the 45-column behind the 44-column until it's Monday.

This PR fixes this. The method now returns the column that matches the current sprint's number.
If none of the "Done ..." columns matches, it just returns the first one (like it was before)
