### PR TITLE
Fix issue #44 - set-priorities command fails with cards having '#' in the title

### DIFF
--- a/lib/trello_wrapper.rb
+++ b/lib/trello_wrapper.rb
@@ -15,6 +15,7 @@
 #  To contact SUSE about this file by physical or electronic mail,
 #  you may find current contact information at www.suse.com
 require 'trello'
+require 'erb'
 
 class TrelloWrapper < TrelloService
 
@@ -76,10 +77,10 @@ class TrelloWrapper < TrelloService
   end
 
   def set_description(card_id, description)
-    client.put("/cards/#{card_id}/desc?value=#{description}")
+    client.put("/cards/#{card_id}/desc?value=#{ERB::Util.url_encode(description)}")
   end
 
   def set_name(card_id, name)
-    client.put("/cards/#{card_id}/name?value=#{name}")
+    client.put("/cards/#{card_id}/name?value=#{ERB::Util.url_encode(name)}")
   end
 end

--- a/spec/unit/trello_wrapper_spec.rb
+++ b/spec/unit/trello_wrapper_spec.rb
@@ -102,12 +102,26 @@ EOF
     end
 
     it "make the attachment with the file name passed.jpg the cover" do
-     subject.make_cover(card_id, image_name)
-     expect(WebMock).to have_requested(:put, "https://api.trello.com/1/cards/#{card_id}/idAttachmentCover?key=mykey&token=mytoken&value=#{image_id}")
+      subject.make_cover(card_id, image_name)
+      expect(WebMock).to have_requested(:put, "https://api.trello.com/1/cards/#{card_id}/idAttachmentCover?key=mykey&token=mytoken&value=#{image_id}")
     end
 
     it "shows an error if the file was not found in the attachment list" do
       expect { subject.make_cover(card_id, "non_existing_file.jpg") }.to raise_error(/non_existing_file.jpg/)
     end
+  end
+
+  describe "#set_description" do
+    let(:card_id) { "c133a484cff21c7a33ff031f" }
+
+    before(:each) do
+      stub_request(:put, "https://api.trello.com/1/cards/#{card_id}/desc?key=mykey&token=mytoken&value=Bug%20%235").
+                 with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'Content-Length'=>'0', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Ruby'})
+    end
+
+    it "handles encoding" do
+      subject.set_description(card_id, "Bug #5")
+      expect(WebMock).to have_requested(:put, "https://api.trello.com/1/cards/#{card_id}/desc?key=mykey&token=mytoken&value=Bug%20%235")
+     end
   end
 end


### PR DESCRIPTION
Trollolo has a subset of methods that change data on a trello board. To
do so trollolo generates URLs which can contain data read from the trello
board.
Since those data might contain characters which are invalid in an URI or have
a certain meaning, we need to escape them.
