### PR TITLE
Adopt to changes of codeclimate-test-reporter gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'codeclimate-test-reporter'
+  gem 'codeclimate-test-reporter', '>= 1.0.0'
   gem 'rspec', '~> 3.5'
   gem 'cli_tester'
   gem 'webmock'

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require "simplecov"
+SimpleCov.start
 require_relative '../../lib/trollolo'
 require 'given_filesystem/spec_helpers'
 require 'webmock/rspec'


### PR DESCRIPTION
Version 1.0 of codeclimate test reporter introduced changes that
break configurations for older versions and thus requires some
adoptations.

In addition this enforces codeclimate-test-reporter version >= 1.0.0.

https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md#upgrading-from-pre-10-versions

====

$ bundle exec rspec
W, [2016-11-23T19:38:05.467313 #5382]  WARN -- :       This usage of the Code Climate Test Reporter is now deprecated. Since version
      1.0, we now require you to run `SimpleCov` in your test/spec helper, and then
      run the provided `codeclimate-test-reporter` binary separately to report your
      results to Code Climate.

      More information here: https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md