### PR TITLE
Fix several issues with SCRUM related commands

### DIFF
--- a/lib/card.rb
+++ b/lib/card.rb
@@ -18,7 +18,6 @@
 class Card
   # Assuming we have card titles as follows '(8) This is the card name'
   ESTIMATED_REGEX     = /\(([\d.]+)\)/
-  PRIORITY_REGEX      = /^(?:\([\d.]+\) )?P(\d+): /
   SPRINT_NUMBER_REGEX = /\ASprint (\d+)/
 
   def initialize(board_data, card_id)
@@ -41,19 +40,6 @@ class Card
   def story_points
     return 0.0 unless estimated?
     name.match(ESTIMATED_REGEX).captures.first.to_f
-  end
-
-  def priority
-    return unless m = name.match(PRIORITY_REGEX)
-    m.captures.first.to_i
-  end
-
-  def priority=(n)
-    if priority
-      @card_data["name"].sub!(/P\d+: /, "P#{n}: ")
-    else
-      @card_data["name"] = "P#{n}: #{name}"
-    end
   end
 
   def done_tasks

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -295,17 +295,17 @@ EOT
 
   desc "set-priorities", "Set priority text into card titles"
   long_desc <<EOT
-  Add 'P<n>: ' to the beginning of every cards title, replace where
-  already present. n is the current position of the list on the card.
+  Add 'P<n>: ' to the beginning of every cards title in the 'Backlog' list,
+  replace where already present. n is the current position of the list on
+  the card.
 EOT
   option "board-id", :desc => "Id of the board", :required => true
-  option "list-name", :desc => "Name of the list", :required => true
   def set_priorities
     process_global_options options
     require_trello_credentials
 
     p = Scrum::Prioritizer.new(@@settings)
-    p.prioritize(board_id(options["board-id"]), options["list-name"])
+    p.prioritize(board_id(options["board-id"]))
   end
 
   desc "list-member-boards", "List name and id of all boards"

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -324,8 +324,8 @@ EOT
 
   desc "sprint-cleanup", "Move remaining cards to backlog"
   long_desc <<EOT
-  After the sprint, move remaining cards from 'Sprint Backlog' and 'Doing'
-  back to the planning board into the 'Ready' list.
+  After the sprint, move remaining cards from 'Sprint Backlog', 'Doing'
+  and 'QA' lists back to the planning board into the 'Ready' list.
 EOT
   option "board-id", :desc => "Id of the board", :required => true
   option "target-board-id", :desc => "Id of the target board", :required => true

--- a/lib/scrum.rb
+++ b/lib/scrum.rb
@@ -5,6 +5,7 @@ require_relative 'scrum/card_type_detection'
 require_relative 'scrum/sprint_board'
 require_relative 'scrum/sprint_planning_board'
 
+require_relative 'scrum/priority_name'
 require_relative 'scrum/prioritizer'
 require_relative 'scrum/sprint_cleaner'
 require_relative 'scrum/backlog_mover'

--- a/lib/scrum/card_type_detection.rb
+++ b/lib/scrum/card_type_detection.rb
@@ -1,5 +1,9 @@
 module Scrum
   module CardTypeDetection
+    def sticky?(card)
+      card.labels.any? { |l| l.name == "Sticky" }
+    end
+
     def waterline?(card)
       card.name =~ /w.?a.?t.?e.?r.?l.?i.?n.?e/i
     end

--- a/lib/scrum/prioritizer.rb
+++ b/lib/scrum/prioritizer.rb
@@ -9,12 +9,11 @@ module Scrum
     private
 
     def update_priorities
-      priority_name = PriorityName.new
       n = 1
       @board.backlog_cards.each do |card|
         next if @board.sticky?(card) || @board.waterline?(card)
         puts %(set priority to #{n} for "#{card.name}")
-        card.name = priority_name.build(card.name, n)
+        card.name = PriorityName.build(card.name, n)
         card.save
         n += 1
       end

--- a/lib/scrum/prioritizer.rb
+++ b/lib/scrum/prioritizer.rb
@@ -1,36 +1,23 @@
 module Scrum
-  class Prioritizer
-
-    def initialize(settings)
-      @settings = settings
-    end
-
-    def prioritize(board_id, list_name)
-      list = find_list(board_id, list_name)
-      fail "list not found on board" unless list
-      update_priorities(list)
+  class Prioritizer < TrelloService
+    def prioritize(board_id)
+      @board = SprintPlanningBoard.new.setup(board_id)
+      fail "list named 'Backlog' not found on board" unless @board.backlog_list
+      update_priorities
     end
 
     private
 
-    def trello
-      @trello ||= TrelloWrapper.new(@settings)
-    end
-
-    def update_priorities(list)
+    def update_priorities
+      priority_name = PriorityName.new
       n = 1
-      list.cards.each do |card|
-        next if card.name =~ /waterline/i
-        card.priority = n
-        trello.set_name(card.id, card.name)
+      @board.backlog_cards.each do |card|
+        next if @board.sticky?(card) || @board.waterline?(card)
         puts %(set priority to #{n} for "#{card.name}")
+        card.name = priority_name.build(card.name, n)
+        card.save
         n += 1
       end
-    end
-
-    def find_list(board_id, list_name)
-      board = trello.board(board_id)
-      board.columns.find { |list| list.name == list_name }
     end
   end
 end

--- a/lib/scrum/priority_name.rb
+++ b/lib/scrum/priority_name.rb
@@ -2,12 +2,12 @@ module Scrum
   class PriorityName
     PRIORITY_REGEX      = /^(?:\([\d.]+\) )?P(\d+): /
 
-    def priority(name)
+    def self.priority(name)
       return unless m = name.match(PRIORITY_REGEX)
       m.captures.first.to_i
     end
 
-    def build(name, n)
+    def self.build(name, n)
       return name.sub(/P\d+: /, "P#{n}: ") if priority(name)
       "P#{n}: #{name}"
     end

--- a/lib/scrum/priority_name.rb
+++ b/lib/scrum/priority_name.rb
@@ -1,0 +1,15 @@
+module Scrum
+  class PriorityName
+    PRIORITY_REGEX      = /^(?:\([\d.]+\) )?P(\d+): /
+
+    def priority(name)
+      return unless m = name.match(PRIORITY_REGEX)
+      m.captures.first.to_i
+    end
+
+    def build(name, n)
+      return name.sub(/P\d+: /, "P#{n}: ") if priority(name)
+      "P#{n}: #{name}"
+    end
+  end
+end

--- a/lib/scrum/sprint_board.rb
+++ b/lib/scrum/sprint_board.rb
@@ -16,6 +16,22 @@ module Scrum
       "Sprint Backlog"
     end
 
+    def qa_list_name
+      "QA"
+    end
+
+    def doing_list_name
+      "Doing"
+    end
+
+    def doing_list
+      @board.lists.find { |l| l.name == doing_list_name }
+    end
+
+    def qa_list
+      @board.lists.find { |l| l.name == qa_list_name }
+    end
+
     def receive(card)
       card.move_to_board(@board, @backlog_list)
       add_waterline_label(card) if @under_waterline

--- a/lib/scrum/sprint_board.rb
+++ b/lib/scrum/sprint_board.rb
@@ -25,11 +25,11 @@ module Scrum
     end
 
     def doing_list
-      @board.lists.find { |l| l.name == doing_list_name }
+      @doing_list ||= @board.lists.find { |l| l.name == doing_list_name }
     end
 
     def qa_list
-      @board.lists.find { |l| l.name == qa_list_name }
+      @qa_list ||= @board.lists.find { |l| l.name == qa_list_name }
     end
 
     def receive(card)

--- a/lib/scrum/sprint_cleaner.rb
+++ b/lib/scrum/sprint_cleaner.rb
@@ -1,10 +1,12 @@
 module Scrum
   class SprintCleaner < TrelloService
-    TARGET_LIST = "Ready"
+    TARGET_LIST = "Ready for Estimation"
 
     def cleanup(board_id, target_board_id)
       @board = SprintBoard.new.setup(board_id)
+      fail "backlog list '#{@board.backlog_list_name}' not found on sprint board" unless @board.backlog_list
       @target_board = Trello::Board.find(target_board_id)
+      fail "ready list '#{TARGET_LIST}' not found on planning board" unless target_list
 
       move_cards(@board.backlog_list)
       move_cards(@board.doing_list) if @board.doing_list

--- a/lib/trello_service.rb
+++ b/lib/trello_service.rb
@@ -9,10 +9,6 @@ class TrelloService
     return board, board.lists.find { |l| l.name == name }
   end
 
-  def sticky?(card)
-    card.labels.any? { |l| l.name == "Sticky" }
-  end
-
   protected
 
   def init_trello

--- a/spec/data/vcr/prioritize_backlog_list.yml
+++ b/spec/data/vcr/prioritize_backlog_list.yml
@@ -1,0 +1,2335 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207901064'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      X-Trello-Index-Last-Update:
+      - '322'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '819'
+      Etag:
+      - W/"333-74078a25"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:21 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=97c496a096b8d911283df326025494eb5cb03f797cc74cc6efdc98157802c273; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:21 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"Test Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/test-planning-board","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"sky","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#00AECC","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"Needs
+        QA","yellow":"Under waterline","orange":"","red":"","purple":"Dependent","blue":"Sticky","sky":"","lime":"","pink":"","black":"Pairing"}}'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:21 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207901490'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '541'
+      Etag:
+      - W/"21d-53bde00e"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:21 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=4912e021d8176eb667e5e4318ecc627d683cd007e4cefd980592dc6fcad1e5ac; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:21 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"58496eff1a13c296478de254","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84079,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:21 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/lists/58496eff1a13c296478de254/cards?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207901837'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"sCXSNV60U02aAfNasie0zQ=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2392'
+      Date:
+      - Thu, 08 Dec 2016 14:38:21 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=993f9104a63fb3d683e0d1a1dbf4b4ab2c0246f520c873ed613cb06fc4296d68; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:21 GMT; Secure
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1c+2/bRhL+VxYKcL0UXpnvh4DDwbZsx6lTO1XcNk3zw5Jc
+        yowoLsNdWnCL/O83S4kiJdmWeKYjFRAQBBa5s495fPPNiNSnvztR0Ol1TMdw
+        rVBRVKLqvuZahu0EVLO8zkHHv6X+6ELQ8UAQQXmnl+RxDJdjximIhiTm9KAT
+        wL1LwsWRL6K7SNzDnJqiWljVsOJ8UI2ersG/rmm6f8CcAeU+jJj91SeClNNG
+        wTEjWbEl2/YsalFFCVRd1YnlBPCfQjpy0GXERbltGoaL2zaNYsw7OvZoxn9l
+        Qu7z02d5bXDLMhDUTFd+OhKC+LdjmogTdkezcg9jkuQkLi5VI+YnhcWJR2NQ
+        xCfYI7EdRzEcg1q2HQa6FRiOr3gdWCwhYwpb/JXGzAeF9JCrKApsLGUgqmu2
+        ZXfNgw6XG7qMkhEM/cqvr4X2NYdBHgmGUtd/d+5YoXTloHMX0UmUDKfHmp1q
+        tieee9zPIq92KWRDLx/+NdXy3IbTmaqPJ/IvKSWvsrE86HQImR98+lnaKYtS
+        EbGksnlOS5XBnydsnMZU0Nntbw9dXJCJgmL1GEzJS/vMbDb9GJd6Lp30MW1v
+        6DYziwxE5I/upVZYzMDoHS+GTR10ci4VrWrfPs/McpPFcPdWiJT3Dg9FRuOY
+        dUFLh/5hzVQP6D5fL3gILojvZr6BC9f4dlAPxlWvdtsORkO1diIYDf17BeM5
+        I3EPneeUczS5JeK/ZTxapqkvRePdu/Av7e21vY/GnY/GmqmaRWMpeAg+iIfg
+        HHgofQNL31iKx9XkqLQaj4bbVVWlFo+vXqEj36epIIlPEZxJ0CwifyZ/Jj+i
+        C/EDRwHzc+kSNEC3bIIEQ1meIHFL0R2JI1iTZYglaHAzOEX8nksHk7IfYEAp
+        SqQHoYijjIY0o7BQgEAqJZlALCzmylMOKiPjRZktZm6lDbCoIOFa7aF/a69R
+        f3a8ui79ELOUJhxmGuEVpZbYAWdUbHURPH65dwfjmyB7WfAwm4OHugQeIstb
+        x45HAsbxYfsP33L1zhOAswEC1PTdDAFKQcjHCk5VrOHSzzE4AhYMgyPghx0B
+        swRzwKm1mbtdGg1IYWk7krmtloNR66FTcT+GVDCMAMcg0s4YqwLN1Sx9MdCU
+        q354enX28z5LNw+amu6aBU0pCGnTwqmG6dxkGEyGQzDZuuSpthoSptJV7Xry
+        vCmzVhqlNI4S2kPlScYkSroe47fYj7oQ2CRNi2OVI/mhTJU+HBcndIIDeofh
+        cyoT71MpGdJqRmUqJejkYr6sTCMJOGCRSst5kZdHcSCvgn+zPEMhy0ZoEonb
+        Ytg0Yc/Glhl7PmEhy5EPXsb4Acq9PBH5ASJJgCQWybnQFWDVQGKV3NoWU7Xa
+        Eq93/ID6akU0ndAzbVNmk4dvWTXKf61DftdfowEVwGXQCUt8UDmvaVRqbMU0
+        c8wxbMNcqgy067Mk8yf3L4s52vMx5zsmdzd4KoPPS4ZHLdmkZLgmUTY1UVUz
+        gLPPiwbbrdDnMQdptmKfQkQF0kGrNdM8A53NF7XUTSqVmus0g9xSEHiKilMd
+        65hTgfMU+6VD49KhAX8zPMewuUOvIymkbUR2NHfDckYCnORXBfJdUpJW8QiA
+        Kk8gUAR0nEH1AQfMAGSh/KEz9clbpc6GAKK5N9VZzPIgZHkSZPeHEu+lQinA
+        P8ydFRfwMsgulkVEPDSt3OPi3JNoFB2eQLYRFJMElwfB8iCVHaRRjq8Gb+SJ
+        8lSqMCjKDBrG1BdVSlg4Z5VYfJIgj0Jy4Sn1IxJXgwr8mmtvmh4OUMySIeSt
+        bIxkWSsXhcUiKBaHGSxdJRsJJnDWQgzuhxmoJ8t9kcOaUAGW1d8204hhvGwa
+        qeUKA3KF9RodF9p4VTnhgu/9i8O+/qNq+jxHmCacZjFH6Dp541vvj3auANxi
+        jpjm5Z3JERvAdc2KzeC6FASGbODUwNYUhys4iBJcuRSWHoWlR60Dab/tHrDl
+        mvue01oEMlsuc81n95ws3dHdRcgJvY9vzm5+snYOcrbYc7If7znZ4TN7TjV9
+        NwOHUhDAwcSp2UbPabXANtulc2rXddS2Cmx5s8c4jsZkSFsorK8GqJjqJQvr
+        rRbSL8yANiukrU0KacaXTDFHLNeylCWSxC/tt+/PRz/tC+nKHYi2UyRpVwvp
+        mus0A99SEAppYGbW2kK6hKnHCulV5LVaf2hGs3ei22+2TIMmcPxMKrrECE0x
+        bHeJ1XwdkA+nR2dv9g3+5gylpruGT6nMBCFITFyZaV11ErTLObSu7Rj7pv5u
+        NfVlo2P7XMR+VlNfUzXXXfrG3v3lDz56T1744bt/Fhdxnvxafs9FZmhZc51m
+        MFsKQiFo49R+dlN/lYto7SKy3tWtTZ9R2jf19039J7ik9t2a+k69qf9wT3+e
+        GDRXt5e+7f3ZY++/OGfqzrXVtvltr71TiWEDjK5ZsRlGl4JAhTWcOms6+esA
+        2QzbBmR34SHu57flyITjKf/EHhG8AUNeocfHRx/4CtWFm1zeGUie/AAz3iKz
+        beudkGcxW3cTZis1O8csAyZfKprN380T8vXsak9ma2TW3SnM2lUyW3OdZkBZ
+        CgKZdXHqriWzEl3W8tfW33kx9R3ppbVSRle48RsAsEBAHOMI1RpqhussP712
+        Hnz84t/nb/cNteYNtZrumgVHKQgswsYTTLDANMNxhFe6aqsxYLdLGYyutdBV
+        22IMtP30uKr0EKdE2qQMAFN3zaVOT5Yej06+ULYPgOYBUNNdswAoBSEALJyq
+        Cp7ZaZ3z6+06v9nV7D1fbil823pt81l8WVUbE2ZLU42l10jus35m8QttT5hr
+        Rb6yJ8wbQGLNdZpBYikIkKgDJKr/D2NejVunbcB0Fjq+WyzP2+oYTvdYuY9l
+        KKZOFzBF66HjaARYe0uDooF7Ronsns4hxDVcdfkLJO/d+LeP5/09rXgMKR5R
+        fLO4rYUry0gybPqueM1MDb+smQlCfatBuGrYAw/BfOYhOJx5yDpC0+5rFrKi
+        NXakonVais+1v+IwOD06Pu33+2U06qqquUtVLh1YwcVp/+M+Gnf+1xtqpmoW
+        kaUgJFBnVk8EaysKk7YdgLbZ2pun+wdjG3KCtjDneSXIRq+YPvpkbPFbUEsN
+        /Hdq9lFPjBd+6u2fVY84u/X60K7WIzXXaQanpSAQHAcIzvp3TB94NPbz/wAx
+        T4E0UU4AAA==
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:21 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de26b/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207902101'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-ec2be7ab"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:22 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=c9bde1d8bbcc489d59c9c2e8d47f3a3d660e2d6d75d4c33d103ad1e7178c7b0b; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:22 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"57a7880484e677fd36d48c0b","idBoard":"577b6e6e00d1313a68d3a60a","name":"Sticky","color":"blue","uses":12}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:22 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de259/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207902367'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-ec2be7ab"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:22 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=278cb6c1e4736e9002369625ce45e1a3cdbe204c1c2a4ff0bde6ca595a9261b5; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:22 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"57a7880484e677fd36d48c0b","idBoard":"577b6e6e00d1313a68d3a60a","name":"Sticky","color":"blue","uses":12}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:22 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de260/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207902627'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:22 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=8cb65a07c9c7cd7f64ef9ac81c7abc09c23f6c99ded4876f0a8fc9c04e6e889c; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:22 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:22 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de260?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207903154'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1014'
+      Etag:
+      - W/"FbpoolQK1cf18gZKvEEt7Q=="
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:23 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"58496f001a13c296478de260","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":5,"checkItemsChecked":0,"comments":0,"attachments":1,"description":true,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T14:32:49.110Z","desc":"##
+        Acceptance criteria\n\n* It''s documented how to run the validator on SUSE
+        systems\n* The documentation is referenced or part of the upstream documentation","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":["58496f001a13c296478de28c","58496f001a13c296478de293"],"idLabels":[],"idList":"58496eff1a13c296478de254","idMembers":[],"idShort":250,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[],"name":"P1:
+        (2) Document how to run cf-openstack-validator on SUSE","pos":131071,"shortUrl":"https://trello.com/c/Ry9SmUdr","url":"https://trello.com/c/Ry9SmUdr/250-p1-2-document-how-to-run-cf-openstack-validator-on-suse"}'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:23 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de25b/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207903410'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:23 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=95fd5b011e5a5d6eceb9e1271516552acf06e41fce432b7d43305adb30795fd2; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:23 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:23 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de25b?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207903649'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '735'
+      Etag:
+      - W/"2df-3708d6ca"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:23 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"58496eff1a13c296478de25b","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T14:32:49.626Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":[],"idLabels":[],"idList":"58496eff1a13c296478de254","idMembers":[],"idShort":246,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[],"name":"P2:
+        Etymologie von Foo","pos":139263,"shortUrl":"https://trello.com/c/0ODfEOFN","url":"https://trello.com/c/0ODfEOFN/246-p2-etymologie-von-foo"}'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:23 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de261/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207903881'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '232'
+      Etag:
+      - W/"e8-784bb6e8"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:23 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=9248683fab3d1ddf6f7c31f08c2b2866c6863a057618096118e5a67174bb48b4; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:23 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578cdec184e677fd368fb575","idBoard":"577b6e6e00d1313a68d3a60a","name":"Pairing","color":"black","uses":79},{"id":"578cdec184e677fd368fb576","idBoard":"577b6e6e00d1313a68d3a60a","name":"Dependent","color":"purple","uses":61}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:23 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de261?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207904127'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"Zixa3HEdBcpUQCnnUiJYsw=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 14:38:24 GMT
+      Content-Length:
+      - '685'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA5VUy27bMBD8FYK5tIVlS5Yl2bqlTgsESNEATnpokgNFriwi
+        FCmIlIM08L93KVu2i8J9XARyuZwZ7s7qjUpBc5rMZ4u0DMOIRTGfLtJZNhcw
+        TSM6ogUTa7A0f6Mb4/wiHNGNhBep11+gLqD9hmHEKJmyMKK2KyxvZXESKs26
+        6NY/kAbheAX8+dpBjUjT0+3Sr/wtxOemrkG7HRlzjvHquBfgCRonjaa5aztk
+        EB3QXHdK9culqRsFDvYCticsK8f6Nzw8YVAZe6JS4MkNs+6SO7mR7hXlTsMo
+        DaJpEM7volkeT/MkHEdZ+J3uRGDGfWNdC6wmjWxASQ05qZxrbD6Z1EzqcWFs
+        FXA55mXAmmaM75oMmXZiURAHpQINL4GATYD75lE/6osLcsk5NI5pDgQf66CV
+        zJ98IHcVtECkJYwsrw+0pO20xo4QVwEZcEnRSSV81GhiupaUpn0mL9JVfdrq
+        fvXpkLuHPgL2dy3hWHZjR6QrOu26EWFaENtZ8FjkawMaK8qfvbR9Ua6YYye9
+        ON+WEQUskRoSpPhoWNt7McuKFFIIQxHFUczSucBPyKhP6l2ipPVeeDhj24Wg
+        Tz73hhWgdnnZnAvg0XwGaZaVIk7nZZFkCUKeOUr3EMg0jAeU5a88yayXtJuC
+        vamkWFWmxTvTJPK7y4N5l2YD7fDamumOqT50zDgURg3C3/bTeV7+P5VNsxqr
+        Tm+ZbNENfgiNMqiFFgqbh3tsKNJli+3oz4zpfzJeATpE+KcdOZuuRRscSNNo
+        +3RUGOfkXfyerMCRriFLozn61p7Y0tvuN38jWGMQK5plsyTBf5BvwX2L3qLD
+        NOKUKmX6AeST6e1n3fKXVy/i71kTbGXQxEEcWHBB1wR8kBUMsgKUFRzG+SBr
+        +xOXXyirXgUAAA==
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:24 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de25a/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207904380'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '115'
+      Etag:
+      - W/"73-43cf8364"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:24 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=1f6176a94fb426aa26d83659e5eb8e1a751a8221cb740c4af7c009a5b8270b22; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:24 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578cdec184e677fd368fb575","idBoard":"577b6e6e00d1313a68d3a60a","name":"Pairing","color":"black","uses":79}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:24 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de25a?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207904626'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"1qRkF+78EpEZ+MpaOGjXCw=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 14:38:24 GMT
+      Content-Length:
+      - '731'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41U32vbMBD+V4QKYxtxbSeOnQb20HaDDjq2kXYPW/twls6J
+        qCwZSW7pSv/3nZykSWBlezGSfL7vh+7zE1eSz/l0VpyU2DQ55BMxPimLaiZx
+        PAU+4jXIJXo+f+L3NsRFNuL3Ch+UWX7Btkb3g46pRwPa44j7vvbCqXrvqLHL
+        ul/+JhhqJ1Yo7j4HbKnTdH97HlfxK+ovbNuiCWswCAHEareXGAG6oKzh8+B6
+        QpA98rnptR6W57btNAbcEHjeQ1kEGDT8uqVDbf0eS0lvLsGHUxHUvQqPRHec
+        5WWSj5NsdpUX88l4Ps2OZ+OTn3xNgiqOjtipENgFMAIZ0QroFNyYG/OeXa2Q
+        2Q7N4nrxiV0idMwTA4FaM+VZ3SsdmDJMWBNAGXSegWdrceRefLUKofPzNF2q
+        sOrrY3IlJdK9bGxvpHtMa+tXaXCIaUvE0Q0HyRZly0Fa0Uf3IDrGIPytbeR4
+        2PtB3an03CG5koBJtkKSKOQFImmsS86+Li6ior6LFkoWLHPYaBRhEClpUA51
+        bog5MgwMq5EB8x0KBXpXxKjzzr2hjx8xbc0yIaEtW1oYbCQwZQIuHUGzBxLE
+        AkmO80Nah8/ofePIHteL0BOmbYgpbRHaG7O5yY8QYG+AXp+lEccWlN4WKHlm
+        wQ0Bqqq6xBKzTOaTfALlTNIjiwFSchhtrXwc4F/rrDVZdpi1quS3sfYSatTr
+        umomJIp8VmBZVY2clLOmnlbTTR21ez24xYC7zudm3JVcrKyjb8ZFEXenL7E6
+        t/fotpJaMD3o4WhX8aJeb9k9bf4br3H8T28MtGQt/wbK0ZjE34PVlrjwWoO4
+        o33vY1yrk+fbXXExZ2/Ld+xsuN2jXagOsvTGk9gP+XhCTTpLPfLplNyhH1R0
+        4drRHfJtEGgYtLbrfKWTCVyI8vtpBP93VUpuJl2RlMkwbLtkKJPs2CSRTBLJ
+        PP8BbGSLnHEFAAA=
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:24 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de25c/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207904959'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:25 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=da9b88b5ac0f2f94bec2cd609a58264cff1a933e55b1ec8f4eb0d4959ddf7385; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:24 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:25 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de25c?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207905217'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1014'
+      Etag:
+      - W/"EVxStvvuTY2OTslZQN7xbQ=="
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:25 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"58496eff1a13c296478de25c","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":5,"checkItemsChecked":0,"comments":0,"attachments":1,"description":true,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T14:32:32.695Z","desc":"##
+        Acceptance criteria\n\n* It''s documented how to run the validator on SUSE
+        systems\n* The documentation is referenced or part of the upstream documentation","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":["58496f001a13c296478de27c","58496f001a13c296478de27f"],"idLabels":[],"idList":"58496eff1a13c296478de254","idMembers":[],"idShort":245,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[],"name":"P5:
+        (2) Document how to run cf-openstack-validator on SUSE","pos":163839,"shortUrl":"https://trello.com/c/fbYHFUK6","url":"https://trello.com/c/fbYHFUK6/245-p5-2-document-how-to-run-cf-openstack-validator-on-suse"}'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:25 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de265/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207905474'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '232'
+      Etag:
+      - W/"e8-784bb6e8"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:25 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=a3f5f2d62d45acb940fc9c24dde757c37a0271095fb83be852a47278e6b14ca5; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:25 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578cdec184e677fd368fb575","idBoard":"577b6e6e00d1313a68d3a60a","name":"Pairing","color":"black","uses":79},{"id":"578cdec184e677fd368fb576","idBoard":"577b6e6e00d1313a68d3a60a","name":"Dependent","color":"purple","uses":61}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:25 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de265?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207905712'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"u6l+urUTYCgJfNZ77sn6PA=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 14:38:25 GMT
+      Content-Length:
+      - '678'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA5VUTW/bMAz9K4J22YY4sfMhO7516TB067ANaXdY24Ms04kQ
+        WTIsqcVW5L+PcuIkG5B9XAyJpPgeyUc/U1nSnM6y6ZxVcZzwZCLGczZNsxLG
+        bEYHtODlCizNn+mjceEQD+ijhCepVx+hLqD9imbMUXFlYUCtL6xoZXFiqsyq
+        8KsfCIPpxBrE5spBjZnGp9dFOIVXmF+YugbtdmDcOS7Wx3sJAaBx0miau9Yj
+        QumB5tor1R0Xpm4UONgT2J6gLB3varh7QKMy9oRliZ5rbt2FcPJRuu9Idxwn
+        LErGUZzdJNN8Ms5nyXCeJd/ojgRG3DbWtcBr0sgGlNSQk7Vzjc1Ho5pLPSyM
+        XUdCDkUV8aYZYl2jPtKOgjM3NpI1X8G9vtcvXpALIaBxXAsgWKSDVvLgeU1u
+        1tACkZZwsrg6wJHWa42TIG4N5NOSdKlI4aUqg9VoYnxLKtNuyJN06y5sebt8
+        Syw2Q4BS+9THhN1bSwS229gB8YXXzg8I1yWx3iLNffGX3PGTnp9v/4ACtkL1
+        AbJ8Y3jbaS5NCwYM4rhMJsmEs6zET8xpCOrUoKQNM787I08+pg8h9poXoHZx
+        aSZKEEk2BZamVTlhWVXM0iDjMy62T4FI/RpAVf2KM5t2lHZq34tHlsu1afEN
+        esPt4iDShXmEtq+25tpz1ZmOEYfGqJ74834Lz9P/p7ZpXmPX6WcuW5x+WDaj
+        DHKhheJig3ccIMKl8+3gz4jsPxEvoQFdhtKOmI1vUQYHUJZsH44MWU5eTl6R
+        JTjiG7IwWqBO7YkMUbLE2N/0jMkag7mSOWNxiv+aMILbFrVF+63DbVTKdIsm
+        RvY6ff/l3eZDIPH3qBGOMmpYNIksuMg3kehpRT2tCGlF/cZGB1rbn5Zzx5BG
+        BQAA
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:25 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de266/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207905995'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:26 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=0af598d7598e9d1d7a380bc06b80b8fde8fad475cdc1557697b62334f518c698; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:25 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:26 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de25d/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207906764'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '232'
+      Etag:
+      - W/"e8-784bb6e8"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:26 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=640bdc8f718041313bc4f4c9fd9fbcf43106f725066301b05b99028ebb9693c8; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:26 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578cdec184e677fd368fb575","idBoard":"577b6e6e00d1313a68d3a60a","name":"Pairing","color":"black","uses":79},{"id":"578cdec184e677fd368fb576","idBoard":"577b6e6e00d1313a68d3a60a","name":"Dependent","color":"purple","uses":61}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:26 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de25d?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207906993'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"qJwRkNo5Z1r7V799Op8xww=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 14:38:27 GMT
+      Content-Length:
+      - '684'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA5VUy27bMBD8FYK5tIVlW7ItybqlTg8BUvThpIc8DhS5solQ
+        pCCSDtrA/96lbNkuCvdxEcjlcma4O6tXKgUt6CyfzlOoqpjFE57M02mWC0hm
+        gg5oycQKLC1e6ca4sBgP6EbCi9Srj1CX0H7DMGJUTFkYUOtLy1tZnoQqsyr9
+        6gfSIBxfA3++dlAjUnK6XYRVuIX43NQ1aLcjY84xvj7uBQSCxkmjaeFajwzC
+        Ay20V6pbLkzdKHCwF7A9YVk61r3h4QmDytgTlQJPbph1l9zJjXTfUW4yjtMo
+        TqJxfhtPi0lSzJJhlk/v6U4EZtw11rXAatLIBpTUUJC1c40tRqOaST0sjV1H
+        XA55FbGmGeK7Rn2mHVkUxEGpSMNLJGAT4b551I/64oJccg6NY5oDwcc6aCUL
+        J+/I7RpaINISRhbXB1rSeq2xI8StgfS4pPRSiRA1mhjfksq0z+RFunWXtrxb
+        fjjk7qGPgN1dSziW3dgB8aXXzg8I04JYbyFgkU8NaKwofw7S9kW5Yo6d9OJ8
+        WwYUsESqT5DivWFt58UsK1NIYTwW8SSesDQX+BkzGpI6lyhpgxcedratxuNf
+        bZtP6FPIvWElqF1elnMBPM6nkGZZJSZpXpWzbIaQZ47SPQQynR+PaSdpNwV7
+        U0mxXJsW7yTTLOwuD+ZdmA20/Wtrpj1TXeiYcSiM6oW/7qfzvPx/KptmNVad
+        fmayRTeEITTKoBZaKmwe7rGhSJfNt4M/M6b/yXgF6BARnnbkbHyLNjiQpvH2
+        6agwK8ibyVuyBEd8QxZGc/StPbFlsN1v/kawxoT/SZzM5zH+g0IL7lr0Fu2n
+        EadUKdMNIB/Nv97b5y/MBxF/zxphK6MmiyaRBRf5JuK9rKiXFaGs6DDOB1nb
+        n0isQtBeBQAA
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:27 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de262/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207907269'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '115'
+      Etag:
+      - W/"73-43cf8364"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:27 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=cb7a301fd91a37b2ad28ef7b8cb5e37c60e3f924609ccef907c4b6b0f411dfb0; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:27 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578cdec184e677fd368fb575","idBoard":"577b6e6e00d1313a68d3a60a","name":"Pairing","color":"black","uses":79}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:27 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de262?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207907867'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"BXgI0xNjOGKyZYEPQ/Wq0Q=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 14:38:27 GMT
+      Content-Length:
+      - '717'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41UW2/TMBT+K5Z5AdQsl7ZJ2retgEAaN3XjgW0Pjn2Smjl2
+        ZDudxrT/znHarJ3EBC9R7Byf75Lv+IFKQZd0Xs4WeZ0kKUunPFvks6IUkOUZ
+        ndCKiQYcXT7QrfHhJZnQrYQ7qZvP0FZgf+A29qiZcjChrq8ct7I62qpNU/XN
+        b4TBdnwD/PaThxY7zY+Xq/AWTmF/btoWtN+BMe8Z3xzWAgJA56XRdOltjwii
+        B7rUvVLD68q0nQIPewKPRyhrzwYNVze4qYw7Yinwyzlz/pR7uZX+HulmSZpH
+        aRYl5UU6W06z5Xx6Ms2Tn3RHAitevSKnnEPnmeZAkJYHK9m1vtZvycUGiOlA
+        ry/X78k5sI44ZMBBKSIdqXqpPJGacKM9kxqsI8yRnTh0L3zaeN+5ZRw30m/6
+        6gRdiZF0L2rTa2Hv48q4TewtQNwicbDDRjSijByE4X1wjwXHCPN/axs4Pu99
+        J29lvLKArkRMR6OQKAh5gohqY6Ozr+uPQVHfBQsF8YZYqBVwP4gUGJTnOvfE
+        LBrGNKmAMOI64JKpQxHBzgf3hj5uQpTRTYRCW9IYNtiIYFJ7aCxCkzsURDxK
+        DvlBrcMx/F5btMf23PeIaWpkiktg7bXe/8l3zLOjAL2cpQmFlkk1FkhxZpgd
+        BqgoqhxySBKRTtMpy0uBj4TRUDREW0kXAnz1wqwtCnoTas9ZBWpXV5RcAE/L
+        GeRFUYtpXtbVvJjv67DdOLhQ18+bzWcD7m4+93GXYr0xFs9k8yysTp/GamW2
+        YEdJLdM9U8PWoeJJvRrZPezvjZc4/qc3mrVoLf3GpMWYhOvBKINcaKUYv8V1
+        78K4FovHm0NxuSSv8zfkbPi7h5k6jhie7AwezLLFtMBrxgXplxZ/HB3TjwlQ
+        yuyGKv5Sme+/yg9pQPx3VYwWRl0Z5dGQsMM4SB0dcXj8AwoW/l9dBQAA
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:27 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de25f/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207908424'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '232'
+      Etag:
+      - W/"e8-784bb6e8"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:28 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=3dce9099179f607f9a9b6400bb5cb0d51f5cca7ad41786b8eea887fa81fe3046; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:28 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578cdec184e677fd368fb575","idBoard":"577b6e6e00d1313a68d3a60a","name":"Pairing","color":"black","uses":79},{"id":"578cdec184e677fd368fb576","idBoard":"577b6e6e00d1313a68d3a60a","name":"Dependent","color":"purple","uses":61}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:28 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de25f?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207908981'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"y6qNAwFgAUCRylgHzemBmQ=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 14:38:29 GMT
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA5VTy27bMBD8FYK5tIVlS5at181xWqBAihZwUhRNcqColU2E
+        IlWRTNAG/vcuZct2C7iPi0ByVzuzs7MvVFS0oPNslid1GEYsivk0T2ZpVsF0
+        XtMRLVm1BkOLF/qkrT+EI/ok4Fmo9QdoSug+4zPWqJk0MKLGlYZ3ojx5qvW6
+        dOsfCIPl+Ab443sLDVaanl6X/uT/wvpcNw0ouwNj1jK+Od4r8ACtFVrRwnYO
+        ESoHtFBOyv641E0rwcKewPYEZWVZ38PdAz5KbU5YVhi5ZsYuuBVPwn5HutMw
+        SoJoGoTZTTQr4mkxj8d5lHylOxKYcdsa2wFrSCtakEJBQTbWtqaYTBom1LjU
+        ZhNwMeZ1wNp2jH1Nhkwz8cGCPZvAlU5ZF5TMmnt1ry4uyIJzaC1THAj2aqET
+        zEfekJsNdECEIewASTqnFE6DXC5uzD7nl6DxkRXRiliMrG5Xb4lBLThIea/2
+        vVwxy04kPK/miAJ2JocEUV1q1vUWStMygQTCsIriKGZJVuEnZNQn9cOVwvgR
+        3p1xW5bTB597zUqQu7w04xXwKJtBkqZ1FSdZXc7TOZY8E0r2JRBpcDXU9W+u
+        nvWUdubde0FUq43u8J/pLPe3xcFzS/0E3dBtw5Rjsn86ZhyEkQPxl/1Snaf/
+        T7Ip1qDq9BMTHY7X746WGrnQUjL+iHdnvJfTfDv6M2Lyn4hX0IKqfGtHzNZ1
+        aIMDaBJtH44M84K8il+TFVjiWrLUimvXmRMX1rrr7Yn/t9pv/gx1QKWNV/22
+        QzvRYW9wn6TU/arwyfzLfMm+vfvocf+eNcHpBW0exIEBG7g24AOTYGASIJN+
+        0ej2J1sadrn7BAAA
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:29 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de269/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207909220'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:29 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=05104a9dabc48d86c9bc66a6d03f4bd106c43fe8d941c2f75c73fcc201e6e316; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:29 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:29 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de267/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207909460'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:29 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=1af7d1feb1e1f58e049f0f47b0f0f7a6b3a45b8aa1e2a716aaafd07b51b94818; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:29 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:29 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de267?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207909695'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '713'
+      Etag:
+      - W/"2c9-15d4928a"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:29 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"58496f001a13c296478de267","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T14:32:54.684Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":[],"idLabels":[],"idList":"58496eff1a13c296478de254","idMembers":[],"idShort":256,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[],"name":"P10:
+        seabed","pos":253951,"shortUrl":"https://trello.com/c/rpBkCjeo","url":"https://trello.com/c/rpBkCjeo/256-p10-seabed"}'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:29 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de263/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207909932'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '232'
+      Etag:
+      - W/"e8-784bb6e8"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:29 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=5929c459f3fc2236af39e2c5188022c86e9a164e51639cdd0f0a7debed602be1; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:29 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578cdec184e677fd368fb575","idBoard":"577b6e6e00d1313a68d3a60a","name":"Pairing","color":"black","uses":79},{"id":"578cdec184e677fd368fb576","idBoard":"577b6e6e00d1313a68d3a60a","name":"Dependent","color":"purple","uses":61}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:29 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de263?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207910210'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"fYHp+vGm88jKVly4gy+rmQ=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 14:38:30 GMT
+      Content-Length:
+      - '641'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA5VTy27bMBD8FYK5tIVl62FJtm6O00OAFCjgpIcmOVDUyiZC
+        kQJJOUgD/3uXsmU7B/dxEUjuaGd2d/adiooWNJ1N51kdhhGLEh7Ps2k+qyDO
+        EjqiJavWYGnxTrfa+UM4olsBr0Ktv0FTgvmBz5ijZtLCiNqutNyI8uyp1uuy
+        W/9CGkzHN8Bfbh00mCk+vy79yf+F+bluGlBuT8acY3xzulfgCVontKKFMx0y
+        VB3QQnVS9selbloJDg4CdmcsK8f6Gh6f8VFqe6aywsgds27BndgK94Zy4zDK
+        gigOwtl9NC2SuEjTcZxnP+leBCIeWusMsIa0ogUpFBRk41xri8mkYUKNS203
+        ARdjXgesbcdY12RA2okPFuzVBl3ZKdcFJXP2ST2pqyuy4BxaxxQHgrU6MIL5
+        yBdyvwEDRFjCjpTEdErhNMj14t4eMB+C1kdWRCviMLJ6WH0lFnvBQcondajl
+        hjl21sLL3RxRwMrkABDVtWamt1CelxlkEIZVlEQJy2YVfkJGPagfrhTWj/Dx
+        gtvmIX322DtWgtzj8hmvgEezKWR5XldJNqvLNE8x5YVQdkiBTIOroa4/8qTT
+        XtLevAcviGq10Qb/idPE3xZHzy31FsxQbcNUx2T/dEIcGyMH4e+Hpbos/5/a
+        pliDXaffmTA4Xr87WmrUQkvJ+AveO+u9nM93oz8zZv/JeAMtqMqXduJsO4M2
+        OJJm0e75pDCKCvIp+UxW4EjXkqVWXHfGntmw1qb3JyZotV/9LI6m2Grr2/5g
+        0E90WBxcKCl1vyt88mZuTGZvY0/8d9QExxe0URQkgQUXdG3ABynBICVAKf2q
+        0d1vQlI0Nv0EAAA=
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:30 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de258/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207910461'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '109'
+      Etag:
+      - W/"6d-f9b6b933"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:30 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=86ba863d2a4c8a2271a85ba12f1c29d6224bed65b9f13a81c7771fae56d4f99e; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:30 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"577b6e6e84e677fd3664053e","idBoard":"577b6e6e00d1313a68d3a60a","name":"","color":"orange","uses":12}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:30 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496eff1a13c296478de258?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207910723'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '876'
+      Etag:
+      - W/"36c-d18f07bb"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:30 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"58496eff1a13c296478de258","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T14:32:55.860Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":[],"idLabels":["577b6e6e84e677fd3664053e"],"idList":"58496eff1a13c296478de254","idMembers":[],"idShort":242,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[{"id":"577b6e6e84e677fd3664053e","idBoard":"577b6e6e00d1313a68d3a60a","name":"","color":"orange","uses":12}],"name":"P12:
+        Bike Shedding Feature","pos":294911,"shortUrl":"https://trello.com/c/9bMmWYGD","url":"https://trello.com/c/9bMmWYGD/242-p12-bike-shedding-feature"}'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:30 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de26a/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207910956'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-ec2be7ab"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:31 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=f471491ef168d747fd63320759386e7a0c7c9b54d7f82b5dbc675aeee8639d4b; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:30 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"57a7880484e677fd36d48c0b","idBoard":"577b6e6e00d1313a68d3a60a","name":"Sticky","color":"blue","uses":12}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:31 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de25e/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207911194'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '232'
+      Etag:
+      - W/"e8-784bb6e8"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:38:31 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=f981c839b9d3f920986825008d1e73b8edabe510860c3b27cc6033bd413b3466; Path=/;
+        Expires=Sun, 11 Dec 2016 14:38:31 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578cdec184e677fd368fb575","idBoard":"577b6e6e00d1313a68d3a60a","name":"Pairing","color":"black","uses":79},{"id":"578cdec184e677fd368fb576","idBoard":"577b6e6e00d1313a68d3a60a","name":"Dependent","color":"purple","uses":61}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:31 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58496f001a13c296478de25e?key=mykey&token=mytoken
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207911478'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"yXXoGVyOiGbyYP4hNmIoxw=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 14:38:31 GMT
+      Content-Length:
+      - '678'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA5VU22rbQBD9lWXz0hbLlixbkvWWOoUGElpwUmiTPKxWI2vJ
+        alfsxaEN/veOZMs2AfcCxuxl9pwzM2f0SkVJczrPZoukCsOIRTGfLpJZmpUw
+        nQMd0YKVa7A0f6Ub7bpFOKIbAS9CrW+hKcB8w2PEqJi0MKLWF5YbUZwcVXpd
+        +PUvpEE4XgN/vnbQINL0dLvsVt0rxOe6aUC5HRlzjvH6uC+hI2id0Irmznhk
+        KD3QXHkp++VSN60EB3sB2xOWlWN9Dg9PeCi1PVFZ4s0Ns+6SO7ER7ifKnYZR
+        EkTTIMzuolkeT/E3TufhD7oTgRH3rXUGWENa0YIUCnJSO9fafDJpmFDjQts6
+        4GLMq4C17RjzmgyRdtJd5toGomFreFSP6uKCXHIOrWOKA8EkHRjBupsP5K4G
+        A0RYwsjy+kBHjFcKO0FcDeTLivRQpPBClt2pVkR7QyptnsmLcHUftrpffSIW
+        i8FByj30EbB/awnHcms7Ir7wyvkRYaok1luUuU/+ijl2UvPz5R9RwFLIIUCU
+        HzUzvefStEgggTAsoziKWZKV+Bcy2gX1bpDCdj1/OGPPLKFPXewNK0Du4tKM
+        l8CjbAZJmlZlnGRVMU/nCHnmaoBApmEMoKrejMGsl7Rz+948olzV2uCb6Szr
+        dpcHky71BsyQbcOUZ7I/OkYcCiMH4a/7KTwv/5/KpliDVadfmTDY/W7YtNSo
+        hRaS8WfcYwORLl1sR39mTP6T8QpaUGWX2pGz9QZtcCBNou3TUWEU5+Rd/J6s
+        wBHfkqVWHI1qT3yIniXavjE0orUaweJpmqQL/Nh0Pbg3aC46jB2Oo5S6nzQ+
+        uY3M91jNPncq/h41wV4GbRQHcWDBBb4N+KArGHQFqCsYZjY46Nr+BkrfF/1I
+        BQAA
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:38:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/data/vcr/prioritize_no_backlog_list.yml
+++ b/spec/data/vcr/prioritize_no_backlog_list.yml
@@ -1,0 +1,190 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/xxxxx123?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '15'
+      Etag:
+      - W/"f-472b03d4"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:37:42 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=ecd6bb73d12bbf1c533ff98172b014c54eb148d93ce0c6b0d11717d2328dab55; Path=/;
+        Expires=Sun, 11 Dec 2016 14:37:42 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: board not found
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:37:42 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207878569'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      X-Trello-Index-Last-Update:
+      - '320'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '819'
+      Etag:
+      - W/"333-74078a25"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:37:58 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=a325ff7dbef77d643ecdb8d237b339cf3394115c6adacfb0aafe6ec3ea1b1f81; Path=/;
+        Expires=Sun, 11 Dec 2016 14:37:58 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"Test Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/test-planning-board","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"sky","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#00AECC","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"Needs
+        QA","yellow":"Under waterline","orange":"","red":"","purple":"Dependent","blue":"Sticky","sky":"","lime":"","pink":"","black":"Pairing"}}'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:37:58 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481207878842'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '544'
+      Etag:
+      - W/"220-3da36da7"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 14:37:58 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=6dd82d91b8bcc46e9ef5c2bd8fb47a683f9c5e10d16fdda30cdc7b62a89c38c1; Path=/;
+        Expires=Sun, 11 Dec 2016 14:37:58 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"58496eff1a13c296478de254","name":"Backlog123","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84079,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 08 Dec 2016 14:37:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/data/vcr/sprint_cleanup.yml
+++ b/spec/data/vcr/sprint_cleanup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/7XMd5wmG?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/NzGCbEeN?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -29,7 +29,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -39,48 +39,111 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468923821625'
+      - '1481203114297'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       X-Trello-Index-Last-Update:
-      - '3'
+      - '66'
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"kR6bfMrAjqFpjh0C2DToHg=="
+      - W/"SFWQj1E2s/62p4FKw4aqWw=="
       Vary:
       - Accept-Encoding
       Content-Encoding:
       - gzip
       Content-Length:
-      - '638'
+      - '590'
       Date:
-      - Tue, 19 Jul 2016 10:23:41 GMT
+      - Thu, 08 Dec 2016 13:18:34 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=ace8e3220d793c0a70bd0b10d9a64248f2ea628238e1d00a7d4bc141277396ae; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:41 GMT; Secure
+      - dsc=cf43b43703403bef5094bc1dab015bb91f97c95463bb357a2b882ed5c377c2ac; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:34 GMT; Secure
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4VUy27bMBD8FYKnFjCsOC87vuXVIkXSprUD9BAgIMWVTIha
-        qktKghvk37tU7NppDr0Y0HBfMzvrZ2mNnMuT6czAwemsOFPaTM4O1dlkUsxm
-        EzmSqGrgiCWEeOEVmSPGDIScsRuMQKic0OlBFJ5EJJVXFkvRe6qERRFB1eLc
-        FQRm/IiP+GGZgNqGYD3OxZ2qQNgoQAULNJRwikoQkGo3ZAMEEb2gFsXi9noh
-        JodD1RUIo6IShmwHKPRa5G2IvuYaCGDCo/w43gx6xXFyjq1zI5k7H4AJF8oF
-        GDH3b1QqtL9V5GmY0TFMDwqtZ0fHOeTTiTbqQKtTk3OpxiLupbbkOH4VYxPm
-        WRYJnPPj3NeZzqY/78xJX3/OImumt5qFlaf48P+s1IqgCHL+LBugjVK30EFK
-        9VRyQOcja8yfxgalHY/F1Hxds2icJ2uoNVBg0GJn40DuLR7AFV+8ZcqRWmaT
-        85CXvkuPe8h5+dqlsaQipB7KARpFn1jia3ztvBVE8+JL8i0mPzUtxfVT7715
-        4vBK7j/f1KqEPRXMYTUpYtlNG69/Tce8otYU5DGOEWJmU3TIdukh+6f4uMHy
-        fYNFmtVs9757XFoHW4479IJsuYoIIcn0buJL7zz9tZDCC7hvtbP5TiuG2Elv
-        vu/ZmUm1HXaTlrEBXkbSKQ3uK1/XsOqSAJIDvyb3iu/nPMA6uaNn7AEN+7rn
-        auQspkV4UjiIuPRCgyDoLPSDDSiR3lRB6AU7hC8jWSgZq6Um0ZdX0PAi2S6J
-        p2sTtIg2r9bJG/w7lz/A8U2mXs4OfwCvJ1AN4zRODceQklklxu6VpWSWl5c/
-        vNsB7lIEAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:41 GMT
+        H4sIAAAAAAAAA4VTwW7bMAz9FUK7bEDaJNuapL41aTZk6LJsSW+9yBbjCJEp
+        g5IdtEX/fZSTou162MWAH8lH8j3qUVmjMnUxnhizLYajoZ6MRxeDr5MvYzMY
+        FaqnSFcoGRsMEdY1W4ow9ZqNhAyGQkILisikHeQJh61niKyLvaUSDp73YAki
+        6gqu3JbRnN/RHX3cJKCyIVhPGfzUewQbAXWwyB2F01wiYOKWrgEDRA/cEKxv
+        5msYfu5YdwhGRw2GbYsE+T0UTYi+Eg5CNOFOfTo/DXoteSqjxrmeKpwPKHtv
+        tQvYEwl+canJPugo0zwn1ZboVVLDTnbdxViHrN+PjM7588JX/by/fPg+y+e4
+        7EcR6Sx0Ip3lJ5HCznO8/X+xpNaM26CyR1Ujn6S5wRZTqXC2OqIktT6KsAIZ
+        G3TuMPUQpkqUklpVYZUjBwEttTZ2G73FA7rtD29lz8iNLFbInDPfpuAr5Ko8
+        dqktH/sW2iEZzd9E1zkdOz9rk4vbJfuG0i3VDdcuVbygi0qX+KzrP/A6EZv3
+        wY0VkvcNpmzLXSQMaSkZZ/+m0cw7zxL4MLkcDS7n3dg0xVWTO1u8rCeQOP7m
+        f3US+AVbJP1OwFNPOZ2jW8pj6BwqGVEUVMt0ZfD7SjrdJ1MPgt2Skfs7CBs7
+        S0kJz5rK7hV5yBEYW4uHzjlOq59YCA8gpsoFJ+fTPRyVzNQ11qK9OJyWdU2C
+        1tEW+/tkp3wz9QedvJ3Uy9nuvarugPfdOLXT3SmnYpFKsJW2nPx9evoLDMma
+        awEEAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:34 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203114648'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '546'
+      Etag:
+      - W/"222-273e1966"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:18:34 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=1d045b4cd59996af8a535db44cb468b17ccc4ba28c73212187c87256f181eb95; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:34 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
+        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
+        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:34 GMT
 - request:
     method: get
     uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
@@ -110,7 +173,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -120,35 +183,35 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468923821885'
+      - '1481203114979'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       X-Trello-Index-Last-Update:
-      - '211'
+      - 'null'
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '786'
+      - '805'
       Etag:
-      - W/"312-bf1f7f02"
+      - W/"325-d20b3c91"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:23:41 GMT
+      - Thu, 08 Dec 2016 13:18:35 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=8583efd815b28bc667297b6071bd1d60b95a4033585d5d29704bd32f0201d457; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:41 GMT; Secure
+      - dsc=771afddb91d769fa008da3a3b0947d9f005c0fd64f03943c9e7ea61a7d6da72f; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:34 GMT; Secure
     body:
       encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"TestBoard","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/testboard","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
+      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"Test Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/test-planning-board","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"sky","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#00AECC","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
         waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:41 GMT
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:35 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/578de068f9abd192a911f881/lists?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/lists/58495b6b4e0b95667e0bbb0d/cards?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -175,7 +238,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -185,41 +248,95 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468923822159'
+      - '1481203115250'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"m2r8b2NaW3uALt5BM+VsgQ=="
+      - W/"CugRcx5UZikeHnGTQ51aXQ=="
       Vary:
       - Accept-Encoding
       Content-Encoding:
       - gzip
       Content-Length:
-      - '295'
+      - '2725'
       Date:
-      - Tue, 19 Jul 2016 10:23:42 GMT
+      - Thu, 08 Dec 2016 13:18:35 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=05d92e1aada35c6fad30be5c6e98b8db797f147d6d2ed46620f58ce6d5322918; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:42 GMT; Secure
+      - dsc=6b1b524e4ff554eef8cb96b4aedbcfa8227dea457b6cd38f0b1bb17c552a9a4f; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:35 GMT; Secure
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA6XVMW+EIBTA8a9imB0AFR639XLLjU3HpgMqNKQKRmyXpt+9
-        Dk294bjhvdXAyy/4J7x+szCyE+s0jI4r8Mb2ozDSGiE8gGQ1i3Z2+4rrvKzp
-        y80ubnn/Okwpu32nt1N29T7knOz6YJLY9ywps1MjOa9Z/uzzsIb+f8RP/VjS
-        HJKXZQ1xq852+JjSO8XSCtkiLO1huaQQSYRGagUIQ3cYnp+oAIMAqJtDcD7E
-        sIUUq+SrS4qOCNKYQvTtX4mu+stEtUQMKAQGCpiGhgEuERhTwEgipsFcHlvA
-        CCLGYG5RX8BwEqbhEtPMcB/TGRpGAqaZsYABGkYbTDOugNEkTAsC04wvYBQJ
-        o0AhmjG8gOlIzyI36m4zb79pSZaULwgAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:42 GMT
+        H4sIAAAAAAAAA+2bC2/bOBLHvwrhxeGS3dDWW3KAxSGPNu1t2ubi5LrdtljQ
+        Em1zI0uqSMXNLnqf/WYoyVbcuLZxTp3gkgKpHxqKnPnzN0NSef9XS0St/ZYb
+        OF237/UdbvS7ruf58H+/b/qtvVY44uHVS8XHPcUUl639pIhj+DhOJQfTAYsl
+        32tF8N0pk+ogVOJaqBto0zJMj5oWNYIL0943uvum2e7azm/QZsRlCFccXDMR
+        s76IwWCfBD8FP/nwLyA/EzsgO5TYBvkbSVIh+T6xvN3K8JgpVvdCRIcpy/UI
+        /CCKBqHpmSzwPddwAtuPDC9s4UWnQqqFozQifc0rPu7zXP47VTis9x/xs94o
+        zcHQ8gJ8d6AUC0djnqij9JrndR/GLClYrD+aXTF1DNyc9XkMfnu/oI+B1YKb
+        JWzMoYu9LBeJIr67T/y2abUJJWYXX0AfsxRaMQ23a/jwnRNYju8EJnRNYjdP
+        RXIFDRz96b3+9W1sw/V9Fg0xYH+1rlMdOWOvdS34RCTDcrDVWKueyqIvw1z0
+        Gx8N0mG/GP4JzTaFULY0e3uEr9AKP03HOPzyEjZ1R/keo5eLTIk0ae2rvEDd
+        FLz2I7w8SsdZzBWvOvDlrg9v2YhI3zyG+Mo6aFUgy7dx7fxa6ItCsKKW6jAp
+        EV7doFPSOAUltPoxdGqvVUj0c2B/+VhF5TKP4duRUpnc73RUzuM4bYOTOmGn
+        Eak7XF8sN+yALqnUgqG+S32cbGYXfre+7H17Xgebn9d+Y15vcaJ2v9dEPUlZ
+        vE+ei8/kTcYT8GF4RUQiFYtjpgVez1c3CDzTbfuWZfumZVn+7fnaU4e9fnrw
+        /MHP168n3//bhG2Ear0JWxvChO3SIQiHDsRnmoJuJOqG3tLNsrlrbXzums2c
+        /MMP5CAMeaZYEnICY1Q8F+xD8iH5kbwSil0xIiTJiyQBWZI0IWrEScInZASh
+        mLAcbNJkIIZFroeDZsfpJFFizNEwTNM8Egn0LCIToUba/OjsJVGcjcuLwwIV
+        qK3RoshwHBF+d9RsGb8DL+uWGDYccW3/ukcmaX4lySDNdesRz+L0Bq6SNxJc
+        RlgSoW1U3ahs+iCOCcuVGLBQwfD4p0LkYIJtlPZ4KcHhZSBVUC+8jW8IKyuY
+        mOsrc57laVSE6JnZnbWlKB01KFSR6372Ds6wF0kK9xQ4hH5aqLo9XRGRdKBt
+        MpHxWCQcYwDReY1swNeHcYrTmBTg3JhMOETgmhOmR489aNwdWipj9yHZIpud
+        zbBZ39/3A4d7vj+IbI9BP6ywweYze5/suLvknJc+IFcJSHDqmBmwK0GDmPhn
+        0HnCYtChVLVSdkIWXxeyc83jYrxbE90yXaNrWW2r6zldp+vZ3m2i5xn/xe0W
+        Z/dLdO9hVmAL5GHx1gqoXxTZ9VBfzYvOMYc4RyijGfWzIoeRTLm/EvYb8VwP
+        +7UhYN+hmU1dmleCpFqQtBJkIxOMtSBpmtBakBQFSUtB0lKPVOtxaaIwN50o
+        At9eMVGcgotyINhTpthApjg5fwZuU2VXQVkcBlp65NXFJaIdeGSg32+nh62i
+        3toE6htA9+eAPkN4LbWlDBf5kM0Ybpme4wYLGT7qu6e/DNXkieENhhvfYvgK
+        IG04dT2Q1oYAUotmfhOkM3TGpRCWshN1sJSdzsaLbMNdkZ0HeVjIEoAlwwAu
+        KiV9KO2QHvASSVCCbJwVCpgKQCuBUI6x/C5ReRp3WDQGoCQaeVvkgb1hHgTA
+        A7MNRDgDkiJrmfbavFMQta/5RAEcGoTdGeTpuPJVgwi2FTiLq7r0nYx/C6JP
+        90sE+3ERgf2PRGg4dT0i1IZABJtmATWBCVkpBaqlQJmklRQoSoGCFGiipUBn
+        UqCohIoMS5lgb37hHazIhErDT+XU9sqperUN459fpN/NHhwtm1t5NpfkCSzs
+        Yw6ViUjAfItsdr/bsrwL1LZ2yfF8DVfJe1kJp/3cALYDq3BvIbCv/6n6L14c
+        dJ9KuJkcbPfxLsMb8VwvV9SGkCsgSXSpRb+qHavEsKR01PpbliaMwcaX3Z7X
+        SBMXADNENmBfA2cslCorxLCSh+adQD3ipuI1vgfqTuBmOW4jtgk2EUIYJRSV
+        cTrRcJXgMhWOCO5Oy/YWaWTcSaO6wfB2gx7m5I0e6/yHlP/ekgNyQZ6Rc3JK
+        XpLX8Kr6ZoYfz/VMYyF+zkcnlxdvg5MHd65jPp3D3uZDI1LrgaU2BLAYdEIZ
+        VZTTnMZUUADJ0nqSbRYUVtu0/BXrSSSA5DnMGF0+QeEYpkUueVuC49oRv6PS
+        5MkQ4AFNwEfQvSKq2sn1xUyRmEMP4Wquq52q5boRiXVWn0kRTo8z9Bo14eGU
+        XvN9WKUD50WCxWlpWVZxLCEvLi7OCFSEn2/IjuScVJOhKioVVG9yV9ee4B8p
+        7767mK6hY+hg/0b3QYLqyIlQL4o+GeYpFI4AYTDQZaHuVG1fVc1Vx752Z++y
+        94xgcglBUPO15gWImqtpHQ0j+QP8pCtKaD2X+6TWo0gGOWsnRdVv1GVp3DkW
+        MovZTXukxvE/RPSzCync+frYqNk+Drms67eYAHzzHk/wfbz/KpWqaUCpau9q
+        fX2tDSxU59U4ywuB2e06C/PCJ0tmz8qMfo95IVieF+yHU5a69ipl6eKIrpMx
+        LqEWzWfVUCN13CDaJ9PkYXbnAP7gKuKGlNZLXLVhB2YbzUyD2hTwRKdCpyh0
+        qJJ1QTwTOi2FviyvdTef11Z9QOFinqzINEg7JaBPOcsIbvFNU2B9VbkZoNPH
+        4Zvei299P4X6PLTf20YbqvWPUC7mkINEAmkF/5eyqDJTuZqIyGQkoNIesyvI
+        gXBFKokYsyEv17wDyE5tclgMcVMD4o8jGAjMQZBj62jipBdxzGbUB61MfoeP
+        2+FQIO5NwwQQBVvk+N2F/MY43oS1WZ8OYahnUYOQx3XIZ3juQguLD35OreNP
+        /1JHv2591+AB4dkJHyaeV0BkI5zrIbI2BEQagEhTnzmhvGgtL4Qjyos6Fl3+
+        xKW38c1jq7siFI+Q2uR5WiRRPn8kP9uDK2S9eYrbIhqiOG+ms6ncNsDtAb3/
+        m5a0UiOm5ndccy6LWEnceZ09jKQfcYO+tclL9Xf92BOB2h+qb5aL+IaMOQPL
+        8pgLuod7vcAIvdXb1pvLs+ajW/vUO+9nQ4jmd7BxdfJxp47vEBhc9HV8cXgd
+        nc0GpVs6E3ElOtpTtPIUfdl4Ko+eFKLMh703R9Tb3W1skJfrB1xLAYPxTXVG
+        fdvvTWdv9SjO/35ctkouV/u9R89vOWFKZNt0fG/xwVv2x83bw2hk3i+RnUe1
+        j+s4j5bIjXCuR+TasAMSBiJbQORqHzcc4MSc7uYuZbG7eRavWqB+i8UHb3sP
+        nMLnXELpC4MqJNarVZ/xSE/IsJCyebSYFf1YhOXaWG9Y72GXtLnUO86DnOMu
+        RAblMG4iwRojwhPBLZLR+35kxAdUnTkygi9nTLRN01l8thWkRaryo3t+POlx
+        MdF+vFVqI5zrMbE2BCZ6wESbOreZyCbLH2swNv+oU/Aw/hbo7p3ERUdJ7qaP
+        kn7HH9Ijz8gBOYTfx+T36mc2zR3ftRefIdmnl2fv3ON3D/4M6elvgxqhWm8K
+        14YwhU0qKaeM9uF31Pry8b/4kyjlnTsAAA==
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:35 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/lists/578de068f9abd192a911f883/cards?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb17/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -246,7 +363,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -256,108 +373,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468923822536'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"JC64J54T3UHh5e91Pz6ZOA=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1665'
-      Date:
-      - Tue, 19 Jul 2016 10:23:42 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=deab2295335e84d8b2bd53f2d69dbbfafcb1d85e46bfc6b6d94716037c2bff42; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:42 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+2Z+2/bNhDH/xVCBbZ1CGU9qJd/c15FgrQNaqfB1hYFJdEx
-        YVkSRMpeVmR/+46yZcuJG8ersmRrHcCxJD7vvve5k/Thi8Zjras5nh8zww2G
-        AQ1jM7BoYJrDgPnanhaNWDQ+kWzSl1QyoXXTMkngdJIJBl2HNBFsT4vh2hkV
-        shdJPuXyGsa0DNPFhofNYGD4XdPomp5uWebvMGbMRAQtFr8OqaT1sDzez2jR
-        WJK/tiTfNzXV6IwL+fU2dtXmNZuErBDvM6nW+eGTOtcfZQV0NF1DHfWkpNFo
-        wlJ5kE1ZUa9hQtOSJtWpVYvlTmFyGrIEDPHhK/MHrgaTpXTCYIn9vOCpRC7p
-        Ik/3dISR6cN/WGGewRiWrRNi277jmo5FXNvb04Ra4xlPx2qD745n/rGXQPOQ
-        xlfK/F+0aVb5AbYw5WzG06v5ThcbXSxTlKGICh42Tg2zq7C8+nNu+KVb5yOt
-        Dg/UL9VLnc0mau/zJnRpi/mxcl3Bc8mzdCWDks2teNP4rWxWjZqA10TtioV7
-        5odJbdJ1Pd417AMVUhtf8mh8rXabJRn4VwsTWNSeVgplQNe4+bQw90WRwNWR
-        lLnodjqyYEmS6bD7TtRpuGCDTcvtHTugNiwqGWCXYA/+TB972s3e/cHntR58
-        pvssgs8J/q3ge5XRpItec0nHdA/RGAaVXDD0GsblKSuuETiMUTjzE5oVXDLE
-        UyFpklClanRV8pihYVagg+M6YImr+77reaZlGySwPLIesJejYBoVleZ+BOzT
-        BGzDBbsFbN2xAwrFVyAdPKmUg5fCwZNaOHghHFzJBjdlgyvZYJANjobbojyk
-        bUc5cYxGlL94gXpRxHJJ04ihSC224PRj+jH9FZ3InwWKs6hUEmExGmUzJDNU
-        lCmSI4amNOEwJ6gfQqF/0T9C4loowam+A2hQd50HCxcQTENWMJgoRtArp4VE
-        2bAaq8wFmJpO1vs8HYJstw0ErUBz7nTRL9ZLdLjYXtOW0RBnOVMCicb4jlFr
-        rpjEs3XLN4lFfOI6hmGtg6X37lUe9mL7ccHibASLeR9YzFtgkUX5YK7UDqRr
-        DoycAJa1+VIQavfA6AF0aNhxNzrUHTsgHpw72MK1ljE4G8sMg7PxZmdjoIIA
-        hm2jgU/apoHvNWmgolaqMBxRgZRLuVSBD0KFgzxhkABVtHLlfURDiAA4hsCe
-        wWRFAuDTq8CPIEIFApuDyGnBkIptGY2QYqbQny6qLX9jVMOAVhAPI5cYjuv7
-        BoksiwWupZJTq+XGX2j+d4l6aICO0Dt0hk7QG/i1uLKs+v0g0F3PNTyIdcsx
-        PHc92MeHwimN/VfPror4lmD/TxURDQ/shom6YwfUiGeYYokZLnCCOU7xVgDE
-        UdsAMIOgAYCLOg/nPGcqoLuo3sWE8lQPMzHCEdcBYzTPqy3VLUVHXexmAvMJ
-        vWKqhLivuABOABmAHRQdnCynUwkxBelWmHnbR9VQKCx5EquzkBOzslAV9xjN
-        uBxVzealB5gjAjPXtcdywKovwAz0mYk9VIZlKkuo9dMYKeJ+fMIiw3Ee8z4n
-        XuXI25fY1y9ZDVydmzZULfZL1GcSKjR0kKURmF80rKvufTJxy001xTyDEE+3
-        fZcQJzABresQk6fXyfngdPy4ELO+/VaohYplbtd/hrd4R7ydU17MvbDiG1Qb
-        S8DZ5DZkNuljlxkPGZQ0sdLnas68LKBgWE66dU5rxzkvYMJiVXg0Zr5WtJ0t
-        ZzbJQ3jeEONuPK87wk2hg3PTxjYWTOIyx1EdLrgOl+qerwYkXobLNuaH7TOf
-        tMX8mrs4ZTMcsymG47wF9tfjPib7K3q9Ben2VTWulvaEuYA891xAHpIL7rit
-        zgW+6RmObtvw3/Yt4tx6LDa4HFBOktPvIhc4P3LBs84FDTHulgvqjpALCOQC
-        sjUXLOn54FwQt/7Q37Bbrf/pTOA5aHFIpdghFdzJA/u9gbjDdLgo1JW+Sggb
-        UsATIryVZ4aPiXDnIQhXVl9S27NtotsmMWzP8/zg1tvHP7LTQf9Y/PZdUNv/
-        Qe1nTe2GGHejdt0RqO0CtZ2t1FZc2/qktuWi3detwHgWb2etzW9nFw9RYysi
-        tmsMvdhnAXVJdfPS6kPUz+qD+ugI9dA+fB+iz4tPTa3AClz1riQIDFMBbB1a
-        1tHle3rwpvfsn53+f9/ANlywW6jWHTugQiwwwxSH8B1rN5/+Bh+m0AqqJAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:42 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9e8/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923822839'
+      - '1481203115496'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
@@ -365,24 +381,24 @@ http_interactions:
       Content-Length:
       - '113'
       Etag:
-      - W/"71-1b903a14"
+      - W/"71-dcfd41be"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:23:42 GMT
+      - Thu, 08 Dec 2016 13:18:35 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=13bb410679c20aa345da8999b454e35cef05c78c27286da4e22bbbe0dbf2d291; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:42 GMT; Secure
+      - dsc=0d9ee40c7be25b943e9741999772fd97c4592ce68d6afc54b89642fc33501170; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:35 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f896","idBoard":"578de068f9abd192a911f881","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:42 GMT
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:35 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9e7/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb18/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -409,7 +425,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -419,7 +435,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468923823075'
+      - '1481203115755'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
@@ -427,24 +443,24 @@ http_interactions:
       Content-Length:
       - '113'
       Etag:
-      - W/"71-1b903a14"
+      - W/"71-dcfd41be"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:23:43 GMT
+      - Thu, 08 Dec 2016 13:18:35 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=6ccc5a3f2d99bb92254163433f1cafe816822386cbb0da9d68d0e4a8b2ee24be; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:43 GMT; Secure
+      - dsc=f8830204ef6f1aaabde8b99f71099bf08ec23c88ccf62c410b912d3203b04b20; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:35 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f896","idBoard":"578de068f9abd192a911f881","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:43 GMT
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:35 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9ba/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb12/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -471,7 +487,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -481,29 +497,29 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468923823353'
+      - '1481203116038'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2'
+      - '125'
       Etag:
-      - W/"2-d4cbb29"
+      - W/"7d-ea4c104c"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:23:43 GMT
+      - Thu, 08 Dec 2016 13:18:36 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=8a2c9ff2eab49d5076f8075d55221086d27ff1998635b1b62ad3adc33c3cfebd; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:43 GMT; Secure
+      - dsc=8049e0b5fe558a368d1034c31422b297d4e1476d0d865606cb53b2c263efc93e; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:36 GMT; Secure
     body:
       encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:43 GMT
+      string: '[{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":3}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:36 GMT
 - request:
     method: get
     uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
@@ -533,7 +549,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -543,33 +559,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468923823617'
+      - '1481203116305'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '675'
+      - '674'
       Etag:
-      - W/"2a3-70555c0e"
+      - W/"2a2-402ce24c"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:23:43 GMT
+      - Thu, 08 Dec 2016 13:18:36 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=5daa1b1a2a744c644e46a5b14aa60d1b95eb24188c31dd98de6b96de6f6d5d9a; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:43 GMT; Secure
+      - dsc=a6930eecc63c663d5afe538c72a776e29c46a0ecc67bf2308deca4a9979ae9f4; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:36 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"577b6e7368b58e244f1ebc06","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":65535,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"577b6f351f72355ef16a9074","name":"Sprint
-        Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":262143,"subscribed":false},{"id":"578ccc743212373d0cd3d42b","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":327679,"subscribed":false}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:43 GMT
+      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"57ab15db6568cc9735820ee3","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84863,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:36 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9ba/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb12/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -596,7 +611,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -606,8104 +621,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468923823900'
+      - '1481203116563'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2'
+      - '125'
       Etag:
-      - W/"2-d4cbb29"
+      - W/"7d-ea4c104c"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:23:43 GMT
+      - Thu, 08 Dec 2016 13:18:36 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=93150a2c0b503db5ef1fc57e4d29a5cccd3724eb147f5fa71baae929b1343956; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:43 GMT; Secure
+      - dsc=6b7d69f4564e1d64e7b19a5a72a71c9ebe1219015a33dc6c276f0a84a7a1075a; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:36 GMT; Secure
     body:
       encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:43 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9ba/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923824599'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"TPewUWb1XOvxc8fa4shfig=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:23:44 GMT
-      Content-Length:
-      - '571'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VSTW/bMAz9K4J62Aeixh9xUvuWtcNQoAOGpd1hbQ+yRCdC
-        ZcmQ5BRt0f8+Kk5aF+uwiyHSfI+Pj3yiStKKFosTCcm8bEpey7TMeJmmTVlz
-        OqE1l2vwtHqiWxviI5nQrYJ7Zdbfoa3B/cI0cjRce5hQ39deOFWPUo1d1/36
-        EdsgndiAuDsP0CJTMQ5P4yuiUszatgUThmY8BC42+xh/SogNuqCsoVVwPXaQ
-        PdDK9Fo/jxhXge/0Xj/hjKeH7Ouw/M2woojD+ojBEhTQacDn8y0yautH40gs
-        ueA+LEVQWxUesDxL0jlLFiwtL9OkyvJqNjsu0pPfdFCLFUdHZCkEdIEbAQT1
-        B3CK35gb85mchw+eSCv6OCNIsrH3JFjiekPCBsiWa4U9rSPWkNXV6ivxDz46
-        FrGXWHCA8mgJUZ44aMABNpIEUR13gdhmx9V3Pjjg7VvMXuYZD3ywceTohELL
-        lT4ESn6x3A0ns6jnMIckkWme5nx+IvGTRBf3dmvl48qu/2V4iaXv/yprehtp
-        LngNOlIMEfIN6xNCLGZ5lmb5IpeJkLmcZfWu8XCSL5DVxjrEZGkMli+HdGq3
-        4A4jtdz0XO9SrxUv29YjCYa38Th+FBX5mH0iZ3sPxwsTDbMdGLwjccf+2hxK
-        7CySZbNiUZR4blHelUN36SaEzlfTKa5Ha3uMBzgV0+XPb129lDni+v9XTbOU
-        dQXL2GG5DIWxYBkKY+8LY9Yw33u88z8iyI8xCQQAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f984/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923824871'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-1b903a14"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=d5ddd8a2e502ade8416be188938a8478ba3270ff21ba660d4a772ad4dc42b9d5; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:44 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f896","idBoard":"578de068f9abd192a911f881","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9dc/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923825109'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-f147fbba"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=8b44bf118b28e5995d9301b1f8c073de248e94deb04a286b76ca6b9eedc3dd98; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:45 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f892","idBoard":"578de068f9abd192a911f881","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578de068f9abd192a911f89d","idBoard":"578de068f9abd192a911f881","name":"Pairing","color":"black","uses":34},{"id":"578de068f9abd192a911f89e","idBoard":"578de068f9abd192a911f881","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9dc/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923825359'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-f147fbba"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=6384bd4d971d17107ba4f3a8b4087108d1ae5a008bdd6595b17972fddb691471; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:45 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f892","idBoard":"578de068f9abd192a911f881","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578de068f9abd192a911f89d","idBoard":"578de068f9abd192a911f881","name":"Pairing","color":"black","uses":34},{"id":"578de068f9abd192a911f89e","idBoard":"578de068f9abd192a911f881","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:45 GMT
+      string: '[{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":3}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:36 GMT
 - request:
     method: put
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9dc/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923825762'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"ipTRhgZHeudLkcuqsLRDVQ=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:23:45 GMT
-      Content-Length:
-      - '704'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VUTW/bMAz9K4J22YY48UdiJ7516Q4tOqxA2h3W9iBLdCxU
-        lgxJTtEV+e+jnTjJBnRrL4ZFUnyP5KNeqBQ0p7NsLiBMF+WCFSJaxGwRReVC
-        cDqiBRNrcDR/oRvju59wRDcSnqRef4O6APsDzZijZMrBiLq2cNzK4sRUmnXR
-        rn8hDKbjFfDHCw81ZopPj8vur7uF+bmpa9B+B8a8Z7w6ngV0AI2XRtPc2xYR
-        RAs0161S25OMK896vncPaFTGnTAS6Llizp9xLzfSPyO1OIzSIMyCaHEThXmc
-        5NPZOM1mP+kOECNuG+ctsJo0sgElNeSk8r5x+WRSM6nHhXFVwOWYlwFrmjHW
-        MBki3aRz5sYFsmZruNf3+sMHcsY5NJ5pDgQL8mAl6zyfyU0FFoh0hJHlxQGO
-        2FZr7DrxFZDvK9KnIkUrleisRhPTWlIa+0iepK/6sNXt6itx2AwOSu1THxP2
-        dx3h2FrjRqQtWu3bEWFaENc6pLkv/px5tuvvSatHFLBsNRyk+GKY3WkpK1JI
-        IQxFlEQJS+cCPyGjXVA/ZSVdN8u7QXbsD9nxRUwfutgrVoAa4rgAHs2nkGZZ
-        KZJ0XhazbIopX3HNXnel++xIYqd8znk2TeIoTrJEhFwkYhoXPdudwPcakmJV
-        GYt34rg7nB1kuTQbsEMfaqZbpnrTMeIgPDWU9HLYu9cKe1NDNauhk6YWYMkT
-        qtp2g+3WzCiDnOgzzt08oQHnibiL7ejfyLN3Il8zaVF9J4iFYvzx7YDpOwHP
-        oQGsFnt6hGxa2yg4YGbbhyO/KMnJx+QTWYEnbUOWRnNcE3eyBbgxxLi/1gmT
-        NaZ7otI4mib4rHWjv7UodzosPT4G2Nt+z/nEXz6r65vLvvD/R03iOGiiJEgC
-        Bz5om4APtIKBVoC0guHBCA60tr8BG3GMBLEFAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9db/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923826018'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-be152d8c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=833b38f6ae7df465f31dcfd78c3082a10fe14b5363d51d84717a7911028e4572; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:45 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f892","idBoard":"578de068f9abd192a911f881","name":"Under
-        waterline","color":"yellow","uses":13},{"id":"578de068f9abd192a911f89d","idBoard":"578de068f9abd192a911f881","name":"Pairing","color":"black","uses":33},{"id":"578de068f9abd192a911f89e","idBoard":"578de068f9abd192a911f881","name":"Dependent","color":"purple","uses":3}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9db/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923826304'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-be152d8c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=bd55a6572b5b4eebbe6ed86b524d46372123b9efa8a2357e3bfa96cfa90d5f11; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f892","idBoard":"578de068f9abd192a911f881","name":"Under
-        waterline","color":"yellow","uses":13},{"id":"578de068f9abd192a911f89d","idBoard":"578de068f9abd192a911f881","name":"Pairing","color":"black","uses":33},{"id":"578de068f9abd192a911f89e","idBoard":"578de068f9abd192a911f881","name":"Dependent","color":"purple","uses":3}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:46 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9db/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923826679'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"Z2uF7ijC5zr5tDw55AWBsg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:23:46 GMT
-      Content-Length:
-      - '711'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VUXW/TMBT9K5Z5AdS0+WiTNm9j42FoCKR2ILHtwbFvG2uO
-        HdlOqzH1v3PdNm0RGrCXKL6+Puf43uP7TKWgJZ0UUwFxPlvOWCWSWcpmSbKc
-        iYoOaMXEChwtn+na+PATD+hawkbq1WdoKrDfMIwYS6YcDKjrKsetrM5CS7Oq
-        utVPpEE4XgN/vPbQIFJ6vrwMf+EU4nPTNKD9nox5z3h9WgsIBK2XRtPS2w4Z
-        RAe01J1S2zPEuWc7vXcPGFTGnSkSuHPDnL/gXq6lf0JpaZzkUVxEyWyRxGWa
-        leN8mKfpD7onxIzb1nkLrCGtbEFJDSWpvW9dORo1TOphZVwdcTnky4i17RDv
-        MOoz3cihIA5KRRo2kYB1hOv2Xt/rN2/IBefQeqY5ELyYBytZ2HlPFjVYINIR
-        Ri6vj7TEdlpj9YmvgfS4pOqkEiFqNDGdJUtjH8lG+nqXNr+dfzzmHqBPgLuz
-        jnAssXED0lWd9t2AMC2I6xwELPKlBY0V5Y9B2qEoV8yzfd3PWjCggOVQ/UKK
-        D4bZvceKKocc4lgkWZKxfCrwEzMaknbdV9KFHt/1dmS/2ZHPJvQh5N6wClSf
-        xwXwZDqGvCiWIsuny2pSjBHyha3Jy1v5AR1F7F8E57wYZ2mSZkUmYi4yMU6r
-        ndq98Q/ekmJeG4tn0iwsLo52vTRrsH0dGqY7pnahU8bRkKq/0vPxPb50sf8q
-        qGYNBMtqAZZs0O02NDo8P6MMaqJP6AOzwQD2F3mTeDv4O/XkldRfmbRoxzPK
-        SqF7XsGYv5LxCtCiIlT1xNl2tlVwJJ1uH04Ck3FJ3mbvyBw86VpyaTTHh+PO
-        3kXw/R8PDMFaE4ZXMZ2kBQ680Pxbi4an/TjAMYHV3U0APlp8XzA5Vp+CiH9n
-        jdIsapNxlEUOfNS1Ee9lRb2sCGVFx3lylLX9BW6C3iHLBQAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9dd/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923826959'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-2d28b3b0"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=26efda93c1fa143ecf9da6790d83f1f0f22cf3bee60c135014d1e0cd8a22a598; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f892","idBoard":"578de068f9abd192a911f881","name":"Under
-        waterline","color":"yellow","uses":12},{"id":"578de068f9abd192a911f89d","idBoard":"578de068f9abd192a911f881","name":"Pairing","color":"black","uses":32},{"id":"578de068f9abd192a911f89e","idBoard":"578de068f9abd192a911f881","name":"Dependent","color":"purple","uses":2}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:47 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9dd/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923827615'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-2d28b3b0"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=724c60507a7055a04e03f2b715680c7124b7cffb075241d51c502719266f1ede; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f892","idBoard":"578de068f9abd192a911f881","name":"Under
-        waterline","color":"yellow","uses":12},{"id":"578de068f9abd192a911f89d","idBoard":"578de068f9abd192a911f881","name":"Pairing","color":"black","uses":32},{"id":"578de068f9abd192a911f89e","idBoard":"578de068f9abd192a911f881","name":"Dependent","color":"purple","uses":2}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:47 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9dd/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923828018'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"MB2WTws1sUKuiM5Gd6SDHA=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:23:48 GMT
-      Content-Length:
-      - '669'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VUTW/bMAz9K4J62YY48Vfs2Le03YANHTAg6YCt7UGW6ESo
-        IxmSnKwr8t9HJXGSHrqtF8MiKb5H8lHPVApa0nE+ERBmRV2wSkRFzIooqgsh
-        6IBWTCzA0vKZrrXzP+GAriVspFp8hVUF5juaMUfNGgsDarvKciOrM1OtF1W3
-        +I0wmI4vgT9+drDCTPH58cr/+VuYn+vVCpTbgzHnGF+ezgI8QOukVrR0pkME
-        0QEtVdc027OMM8d2fO8e0Nhoe8ZIoOeGWTflTq6le0JqcRhlQZgHUTGPwjJO
-        yjQfFuPsJ90DYsRta50BtiKtbKGRCkqydK615Wi0YlINK22XAZdDXgesbYdY
-        w6iPtCPvLNnGBl3VKdcFFXP2Xt2riwsy5RxaxxQHgnU5MJJ5zwcyX4IBIi1h
-        R0hiOqWw8+RyOreHmBdO6z0zohVx6Jndzj4Si73g0DT36lDLNXNs366zzg0o
-        YBVNf5DiUjOzl0ZeZZBBGIooiRKWTQR+QkZ90G5ojbR+NHe9itgLFfFiQh98
-        7A2roOnjuAAeTVLI8rwWSTapq3GeYspXXOPXXdkhO5LYC5lznqdJHMVJnoiQ
-        i0SkcbVju9frQRJSzJba4J049YfpUWVXeg2m78OKqY41O9Mp4qijpi/p+bhG
-        rxX2Xw1VbAVeaUqAIRsUqfFz9VujG42c6BPOUW/Q0Fkv7SjaDv4OPX4j9Dcm
-        DerrDLJqGH98A2L2RsRraAHrxa6eMNvOtA0cQYvtw4lgNC7Ju+Q9mYEjXUuu
-        tOK6M/ZsDWptdvuB91vtn5kiRSHi0+TnfWtQ47RfXFxobOhuV/nol/4yn32y
-        Pzzuv6NGcRq00ThIAgsu6NqA90yCnkmATHabTrd/AHwiLR5oBQAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f98b/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923828288'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-1b903a14"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=ebc018d6f9921307bfe9a775e275d4b9ead717349003584ed48e57568adb6c77; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:48 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f896","idBoard":"578de068f9abd192a911f881","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578de068f9abd192a911f881/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923828577'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"m2r8b2NaW3uALt5BM+VsgQ=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '295'
-      Date:
-      - Tue, 19 Jul 2016 10:23:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=f8ff027fa073a613810079730bccd2cf52d621a41f84623abd89e24a0d31fa71; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:48 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVMW+EIBTA8a9imB0AFR639XLLjU3HpgMqNKQKRmyXpt+9
-        Dk294bjhvdXAyy/4J7x+szCyE+s0jI4r8Mb2ozDSGiE8gGQ1i3Z2+4rrvKzp
-        y80ubnn/Okwpu32nt1N29T7knOz6YJLY9ywps1MjOa9Z/uzzsIb+f8RP/VjS
-        HJKXZQ1xq852+JjSO8XSCtkiLO1huaQQSYRGagUIQ3cYnp+oAIMAqJtDcD7E
-        sIUUq+SrS4qOCNKYQvTtX4mu+stEtUQMKAQGCpiGhgEuERhTwEgipsFcHlvA
-        CCLGYG5RX8BwEqbhEtPMcB/TGRpGAqaZsYABGkYbTDOugNEkTAsC04wvYBQJ
-        o0AhmjG8gOlIzyI36m4zb79pSZaULwgAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578de068f9abd192a911f884/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923828841'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"pfnNyZOYaqe3kqQG5n74qw=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1452'
-      Date:
-      - Tue, 19 Jul 2016 10:23:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=7129a1b4623bd33b4d1f85453aa687a8698b6cf74c57aa610df3e7e9f3daeb6b; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:48 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+1XW2/bNhT+K4T60gamLcmxYvstl3YrkG5pnfQhTZFS1JHF
-        RSJdkrLnFPnvO9TFlyxp66Fdi2FFgFK8nMt3vvORfvfJE4k39gYHwwT8aJiO
-        WJwEo5CNgiAdssDreDwDfvPSQjGxzILxxrLMc5zOlQE8mrLcQMdLcO2UGXvI
-        rZgLu0SboR9E1D+gwejcH44DfxxE3f2D0SXaTMBw3NGMTphlrVmRHCmmHw9p
-        6EISyakw9vE9+9WeV1DEoM1bZV2c7967uUmmNB4M3fjQWsazAqQ9VnPQbQQF
-        kyXLq6n1jlWe6JrFkCMM7x7xPoo8dCVZARjgCRP5kky4LgvCLAkCVnRIIlhO
-        hRyTk+dj4kcjGuI/GvqD0ahDji/HZD/0KU4M6GhIB4hh1CFnzBiuEsDFfoB/
-        mOFMYRShvz/0O55xeZ0KeYM+j7I3b0/g8hfcErNk6kr2yZurqna4dS5gIeS0
-        RqcBp0nOlLHhWsQbU6maxuX0ti7Wigq1pfXnsRu5U25WFQ6xegtbIVh/u3Jr
-        MbNCyTV1Sqixv9sYO6QrqzlW2rTla0paf+ZtIT7LYSzHV7KqKdnECn6zdNmq
-        XCErvDjHoDpeaRyAkX/3voH7Que4mlk7M+Nez2rIc9XF7Hu8t1GCBzAtv3yw
-        F9LEUYcaRx3KLHXUoQ1zaAJ0mzeU39K/sYbOGtLQhjN3nc9DlX77dt//Gdo9
-        +Lfa/RxYMSYsKdMUUewQnqEP0DgwOMTWT93/UM8VrFCa5WBwiFFI1SFmrvKc
-        2axDbIawoI1Vnw8i/16fL87iw8siGPzf5z+szzdKsFuftwd7AbXIGdpShjaM
-        oTVh6JovdEUXWrOFtmShK658ob/jb3udh2G3Hw43+vs8AyS1saBJrJnkGVEp
-        EtlN8kxI0EuiAdksrMIhZ5LEQIQkdqGIqaIZX8kruUf29q48NQN55e3tdcgi
-        A9naFYa4BZIqTSQsiFM3dKFVOc1IAXqKjCczzAg9fSwBKUVqc6lWt48YjKE6
-        hKExDUllmuHxHJgBwmRCpCIK09DYzkxinxHcRxgWc4HbEXzMIEP00K7CxJ2x
-        xngFqiZWrQyyOIc6V/JUdKHrzBBknKZzYYRb3PSBiGDbknhJapUirw+rgNyh
-        G6kWsg2TIvOQzrgDm7g+m4o/IXnWdYBeGKjK8OEVuwFSSd0HkqOIYOqYhIvP
-        gK22VKFVh548eUJQEJHRpeti4+ZaKrvWx6nuQtyIAvBS6io97bmv3guRw/gl
-        h2utWHIt5DVavf4NuyhbYDLX56C1K78Ac01Z94/Z9MddCtGDt4I3iMIh84dJ
-        GCQp54Ng4LP0YH8Qe4/eFVaXu18VVfu5Bqm50up84PtRP9wW+ozPFx8vBqOf
-        Tuj794S+BuI/qPMbFdhN59uDPdTOqreoSmlT8ftqPdrKYZSwb/saO+gGI39D
-        rV1/cw4zi0qNsoNtCVqwWoCdkjudnVxMnpNTYDMUBig4JlYJZily64SbK2mZ
-        E3aUHENqKiAwbqlFYypsVsY1Grkqk1SVMtHLXqxM5qCCXo1GNUFbL20MieKl
-        4xpz/HI/oB4w62Lctl0J0bEGBzeTtE2EukRWLijqPD36ffKry6icOQgTp4Qa
-        0hy4rZJMnJZv5dkEhvraXF+MmBlwfJavN1U3yAq9yg4+8XIlp3jX64JMFatg
-        RGdCWphqJwQLTKhS4Fpb62O4nmqER5fclrpSi3KGn/hiuJI/TjgH/e/5nk7Q
-        /yNL4YZ+ngXhmDyNnpGjCqk1PzfL1arqQT/qD+6panDxOp68ebH/fVV18KCq
-        hrs8n3dR1RY5toUcH3LvH+ttsqPenjHh3kBbgsuqHzK14vaDL/0MDXf0eCET
-        7LoFtpHGVw1seF46KV6sXAfB14j9BjF2E/v2YA87hM6CkEa0auO15uBP9w1y
-        3r3/C74JL1V/EwAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de068f9abd192a911f8a1/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923829150'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-1b903a14"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=a3ef08235bbf4caf1987be724ad460c67437b767422b75fb69eb55efb762e3db; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:49 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f896","idBoard":"578de068f9abd192a911f881","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:49 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de068f9abd192a911f89f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923829432'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-1b903a14"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=4dc2e933e67bec696a3ad1d35d0ad867ee9a13e8f0651f184aab61e754b115ce; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:49 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f896","idBoard":"578de068f9abd192a911f881","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:49 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de068f9abd192a911f8b1/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923829691'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-1b903a14"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=4ba95aced635830a754e439dbf8aa476666a459ac26d74c494139474f26cc893; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:49 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f896","idBoard":"578de068f9abd192a911f881","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:49 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9da/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923829959'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-a4d376be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:50 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=547994170164dd6a344c37c63ad52cabeef62bfa85cbb41e0dd5fa1b5277b3cd; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:49 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f892","idBoard":"578de068f9abd192a911f881","name":"Under
-        waterline","color":"yellow","uses":11},{"id":"578de068f9abd192a911f89d","idBoard":"578de068f9abd192a911f881","name":"Pairing","color":"black","uses":31}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:50 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9da/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923830211'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-a4d376be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:23:50 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=76fae4770c45be1a4f55c039e759678f813b216e40e5261bb771c33895bb310a; Path=/;
-        Expires=Fri, 22 Jul 2016 10:23:50 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578de068f9abd192a911f892","idBoard":"578de068f9abd192a911f881","name":"Under
-        waterline","color":"yellow","uses":11},{"id":"578de068f9abd192a911f89d","idBoard":"578de068f9abd192a911f881","name":"Pairing","color":"black","uses":31}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:50 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578de069f9abd192a911f9da/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468923830584'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"4Kgf/nxJKvJT8jUNdpQ4Bg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:23:50 GMT
-      Content-Length:
-      - '777'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VUy27cOBD8FUK5bIJR9LI0j5vt7CIBHCTZifewsQ8tsjVD
-        mCIFkvLAMfzvaUqWRwZiJLkIItndVdWs5n0kRbSJyuVKYFqtmzXUIlvnsM6y
-        Zi0gWkQ1iB26aHMf3RofftJFdCvxIPXuI7Y12v9om2o0oBwuItfXjltZz7Ya
-        s6v73XeCoXJ8j/zmg8eWKpXz5Xn4C1k57Zq2Re1HMPAe+P64FhgAOi+Njjbe
-        9oQgeow2ulfqYVZx62Hg++2eNJ5Pu0ex8EwsXwli50IOhRCBTiH9Pix+M7v5
-        afY18VHGzZohKOQCnD/lXt5Kf0fheZpVcbqMs/XXLN3kxaZM35bF+v9o1EoR
-        r16xU86x86A5MlLv0Uq40lf6Dfu6R2Y61NvL7d/sAqFjjohyVIpJx+peKs+k
-        ZtxoD1KjdQwcG3tIlxSO9t53bpMkO+n3ff2W2CdEuheN6bWwd0lt3D7xFjFp
-        iTjaYSOeUCYOwvA+XBKEi2Hgf1Y2cHxe+yBvZHJukboSg44nIXEQ8gQRN8bG
-        Z5+274OivgstFMwbZrFRyP0gUpAfn+t8JGapYaBZjQyY65BLUMcgRpWP3Rvq
-        uAVTRu9iEtqynYGhjQQmtcedJWh2IEHMk+RgU9I6pNF5Y6k9tue+J0zTEFNa
-        IrRX+vEm34GH0aczyy4ibEGqaSHFmQE7zuSyrrDCNBVZkRVQrQR90jCTj45U
-        0oWZ+PaSJ3l0HWIvoEY1xXGBPFudYLVcNqKoVk1dLk+o5AtH5WMJQhq9zzlf
-        nhR5lhfLQqRcFOIkrwdK42sQcIaU7d5YysnLsDh9muFzc4t2EtuC7kENW8eI
-        p1FRE+/7p0fqJfa/1TUNbZjOSy3o4g90k1aRB8KbZJQhTtEdec0caKN34eHI
-        8nH6X4Yu/xD6M0hLPp1B1gr4zRzx+hic5Rv2V/WanQ3+Ok713OSU2hnKLLIs
-        X1OrXej6pSU7RdP8kQdJ1jjWSXb5pd7++0/oWf/rqCQv4y7L4yoePH4cSKnj
-        GYeHH2/aJA1GBgAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:23:50 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/uQjRuX1w?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924837125'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '3'
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"F3om5DH+AAu0DSksj2YXYA=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '638'
-      Date:
-      - Tue, 19 Jul 2016 10:40:37 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=4bd2c8c7f279cb259bd4bcac2a7f9c8fa858d16a26c415711729b196679111ec; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:37 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VUy27bMBD8FYKnFjCs2Enq1Le8CqRI0yR2gB4CBKS4kllR
-        S3VJSXCD/HuXil07zaEXAxrua2Zn/SytkXN5PDuBg8Pjw0LPpqBnR2r6WeXH
-        SsuRRFUDRywhxDOvyEwZMxByxq4wAqFyQqcHUXgSkVReWSxF76kSFkUEVYtT
-        VxCY8SM+4odlAmobgvU4F99UBcJGASpYoKGEU1SCgFS7IRsgiOgFtSgW15cL
-        MZkOVVcgjIpKGLIdoNBrkbch+pprIIAJj/LjeDPoBcfJObbOjWTufAAmXCgX
-        YMTcv1Op0P5WkadhRkcwOyi0Pjk8yiGfTbRRB1p9MjmXaiziXmpLjuNXMTZh
-        nmWRwDk/zn2d6ay9+3nf/pj0WWTN9FazsPIUH/6flVoRFEHOn2UDtFHqGjpI
-        qZ5KDuh8ZI3509igtOOxmJqvaxaN82QNtQYKDFrsbBzIvcUDuOKrt0w5Usts
-        ch7y3HfpcQ85LV+7NJZUhNRDOUCj6AtLfImvnbeCaF58Sb7F5Kempbh+6r03
-        Txxeyf3nq1qVsKeCmVaTIpbdrPH612zMK2pNQR7jGCFmNkWHbJcesn+Kjxss
-        3zdYpFnNdu+7x6V1sOW4Q8/IlquIEJJM7yY+987TXwspPIPbVjub77RiiJ30
-        5vuWnZlU22FXaRkb4GUkndLgbvi6hlWXBJAceJPcK+5OeYB1ckfP2AMa9nXP
-        1chZTIvwpHAQcemFBkHQWegHG1AivamC0At2CF9GslAyVktNoi8voOFFsl0S
-        T9cmaBFtXq2TN/h3Lu/B8U2mXs4OfwCvJ1AN4zRODceQklklxm6VpWSWl5c/
-        NiM/uVIEAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:37 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924837395'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '236'
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '786'
-      Etag:
-      - W/"312-bf1f7f02"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:37 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=ae0ffafa033e3a0b683a9f13d7d98e6fd7144a90bb53543785335a003db2926c; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:37 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"TestBoard","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/testboard","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
-        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:37 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e0353fb72eb74a29ac5ab/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924837711'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"4yoUSUSYmVD4Luvn1wd//Q=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '298'
-      Date:
-      - Tue, 19 Jul 2016 10:40:37 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=f9e2e1b5847709b0cae237de1a850c1423f6f722494d4f580bd6c29fe3841fdc; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:37 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1g7mRrlKVj1bHqAA6uUG2wjJOl6rvX
-        Q1VnCJF6zmrB0Sf8I96+SDyTA5HaBMolH7xmwWvhmHW9dD1pSXJT2FY8T/OS
-        r2EKaS3b137MJWw7BzeW0G5DjtktDyb5bc+cCzlwRmlLysWXfon+b8R3+1hy
-        3iWv8xLT2hxd/znmD4xFdEwALGG3nHJMKAJnWhmAYdgNL09YgP0/wNObQwhD
-        THGNOTV5aE45BSRIAwrx3e1fSaH5zUQJJMYoAIZVMByHMZQBMLyCYUgMB1we
-        LyqYDomxgFvkZQVDURhOGaQZdR8jLQ7DDKQZXcEYHEZbSDOmgtEojDAdpBlb
-        wSgURhkFacZVMBL1LFKr7jbz/gOkxgUfLwgAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:37 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e0353fb72eb74a29ac5ad/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924838093'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"0/v1KSlkC7TUd5P6gZ49lQ=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1671'
-      Date:
-      - Tue, 19 Jul 2016 10:40:38 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=0b9b5101c2d7b8230ddad09704f5006a2dc1c0cd3327e88f5fd46ef97c818235; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:38 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+1Za2/bNhT9K4QGbOsQynpT8re8uqZ1lqxONqwPFBRF22xk
-        SRCpGGmR/fZdypYtJ24co86SrbUBWxJ5+bj3nHOvpLefDZEYXcMnIbdc3x/E
-        xOEx8agTUUacxNgx2IiziyPFx31FFZdGN6vSFC6nueRgOqCp5DtGAm09KtUu
-        U+JSqCsY07HsAFsE29GZbXXdqGsTM/DcNzBmwiWDHrOjA6poM6xI9nJatpbk
-        Li3Jp7GhO/WEVF/uk9R9jvk45qX8I1d6nW/f62v9UV6CoR1Y+mxXKcpGY56p
-        /fySl80axjSraFpfWvSY7xQmpzFPwRFvvzA/swyYLKNjDkvsF6XIFAq8LiIm
-        MRFGdgj/sMIihzEc1/Q81w39wPYdL3DJjiH1GnsiuwDrTzRVw6PoBLrHNBlq
-        9382LvM6DrCFS8EnIhtOdzrb6GyZsoolK0XcujTIh3E1/DR1/Dys05EWp/v6
-        SFvpq/lY733ahc59MT3XoStFoUSeLWBQ8akXr1vH2mf1qClETTahmIVnepo2
-        Ll3G423H3hMhjfOVYBdXerd5mkN8jTiFRe0YldQODKzr9zN3n5cptI6UKmS3
-        01ElT9PchN13WKcVghU+rdYbdgBtWNYwwIGHCXztEBPjeudu8rGtk88lT4J8
-        fvRvke/XnKZddCwUvaA7iCYwqBKSo2MYV2S8vEIQME7hyo9oUgrFkcikomlK
-        NarRsBIJR4O8RPvPG8J6gRmGASG241pe5BBvmbB+r//6+fGk+E7YRyNsKwSb
-        EbYx7ABC8RCgg8c1cvAcOHjcAAfPgINr2OA2bHANGwywwWywhuXBgG+b5aEX
-        tFj+ww9olzFeKJoxjphebCnou+xd9gs6Uj9JlOSs0hDhCRrlE6RyVFYZUiOO
-        LmkqYE5AP1Chf94/RPJKasBp2zPo0JhOySIkkGnASw4TJQisCloqlA/qsapC
-        gqvpeNnm8STIDbYhQQuhOfW76GfnGTqYba/tSzbAecE1QNgFvuXURldsj7im
-        E9qe40EEfctyloXltAr7Quy9eFhh8VcKi32XsNg3hEWV1b11pQlgsBTAKKKw
-        rNVNCTPuEKN7qEPLj5upQ2PYAfDgwscObrCMIdhY5RiCjVcHG4MqSNCwdWrA
-        yHbVIDRdt60GmrVK03BEJdIhFUoTH4AKJ0XKIQFqtgodfURjYACcA7EnMFmZ
-        gvCZNfEZMFQi8DmAnJYcaW4rNkJaM6X5eKx2wpWshgGdKBmwwLP8IAwtjzkO
-        jwInMLZcbvyNpt8/0S46Q4foNeqhI/QbHM1a5lV/GEVmQAKLANcd3yLBMtlf
-        TE6iV8dH8slVEV9D9v9UEdGKwGYy0Rh2AI14gilWmOMSp1jgDK8TAOLYWy/6
-        7fYd93mThwtRcE3oLmp2MaYiM+NcjjATJsgYLYp6S01P2dGN3VxiMaZDrkuI
-        u4oL0AlQBtAOivaP5tPphJgBdGuZOemjeigUVyJN9FXIiXlV6or7Ak2EGtXd
-        pqUHuIOBm5vaYz5gbQtiBvjM5Q6q4ipTFdT6WYK04r57xCLD9x/yPocscuTN
-        pvCLTTFrydWp7ULV4j5Dfa6gQkP7ecbA/bLlXX3vk8sbYWpUjFieR0w3DDzP
-        j2yQ1mURu3r5sTfZP6UPK2LO198KbaFiSdy7ypK75Y1sKG+nVJTTKCz0DaqN
-        ucC53k2RWYWPTWY84FDSJBqfizmLqoSCYT7pujljtuGc5zBhuSg8WjNfabWd
-        zGe2vfvoeQuMm+l5Ywg3hT4ubBe7WHKFqwKzhi64oUt9z9cIJJ7TZZ3mW9vW
-        fD+KtqX5je7ijE9wwi8xnBdb0P5m3IfU/lq9TgC6fV2N66U9Yi7wnnou8O6T
-        C26FrckFoU0sH+424N8NHc+/8Vjs8K83L3us+PRN5ILgey540rmgBcbNckFj
-        CLnAg1zgrc0Fc/W8dy5wtl7/O9ZW6386kXgqtDimSm6QCm7lgb3dM3lL06FR
-        6pa+TggrUsAjSvhWnhk+pIT795Fw7fW5ahPX9UzX9iyXEBJGN94++scWYb2r
-        3jeh2tF31X7Sqt0C44avdWaGoNoBqLa/VrW1rq19Urvl9zah6RH/SbyddVa/
-        nZ09RE0c5rmBNSBJyCMaeEm87YeoH/QH9dEh2kV78HuAPsw+jWpFThTodyVR
-        ZNlawJZFy/398KPL8ldP/tnp//cNbCsEm1G1MewACrHEHFMcw29iXL//B3kv
-        0kGqJAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:38 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac72d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924838386'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-d452f87f"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:38 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=bc10d8cb7fd68513b415df856f6589eaabd2d67d7cc8f3c8bacec38166f6c5d1; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:38 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5c0","idBoard":"578e0353fb72eb74a29ac5ab","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:38 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac72c/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924838630'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-d452f87f"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:38 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=ad1fa4ebbd60651f95548d751184d9cea24ddf76f5d9c1ea1afcda06348fc2e0; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:38 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5c0","idBoard":"578e0353fb72eb74a29ac5ab","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:38 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac6fe/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924838864'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:38 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=81958f1c7c722dbaf5be995bd0d2a81e3c64ec3b04f02dba0dc125b1be11b92f; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:38 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:38 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924839146'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '675'
-      Etag:
-      - W/"2a3-70555c0e"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=b480a117b023cbd55643cfe2ffb258008a370ad2210aab413868da6a44283be5; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"577b6e7368b58e244f1ebc06","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":65535,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"577b6f351f72355ef16a9074","name":"Sprint
-        Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":262143,"subscribed":false},{"id":"578ccc743212373d0cd3d42b","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":327679,"subscribed":false}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac6fe/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924839400'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=d934212fe1eaee3b0393963c95eb80a855d32320d6e29c37ff548377e3836e6b; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:39 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac6fe/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924839724'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"97jgbjqNKV77wbCQt2j9dQ=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:40:39 GMT
-      Content-Length:
-      - '571'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VS207jMBD9Fcs87EU1zaVNmrxBWWmRWAmpsA8LPDj2pLVI
-        7Mh2itiKf99xQ0vQstqXyDM558yZy44qSUs6zxcQpfN5XeUJVPmMJwUXWQ10
-        Qisu1+BouaNb48MjmtCtgiel1z+grcD+xDRq1LxxMKGur5ywqhqlarOu+vVv
-        LINyYgPi8dJDi0rzcbgMr8CKMWvaFrQfinHvudi8xvhTQijQeWU0Lb3tsYLs
-        gZa6b5qXkeLK873fux32uDxk35rN3jVbFBW6c4GDEDTQNYDPlwdUbIwbtSMR
-        csWdPxNebZV/RngSxRmLchYXN3FUzqIyLU6zRfGLDm4RcXJCzoSAznMtgKB/
-        D1bxe32vv5JL/8kRaUQfegRJNuaJeENsr4nfANnyRmFNY4nRZHW7+kbcswsT
-        C9wbBByoPIyEKEcs1GABC0mCrI5bT0y91+o75y3w9j3n1eYF93wY42iiEwot
-        V80hUPLccDucTF5lkEEUyTiNU54tJH4iTieHcTfKhZXd/WvgAfrxLynoQ5C5
-        4hU0QWKIUG9YnxAin6VJnKR5KiMhUzlLqn3h4SSPlNXGWOQkWQjOjoe0NFuw
-        h5Zarnve7FNviOO2m5EFzdtwHNfzknxOvpCL1xmOFyZqZjrQeEfikf21ObTY
-        GRRLkzzLCzy3YO/W4nTpxvvOldMprqdpzCke4FRMr/vFSqnz78jr/4+aJhnr
-        5ixhh+UyNMa8YWiMfWyMGc1c7/DO/wBmOBZ9CQQAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac6c7/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924839989'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-d452f87f"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:40 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=c74ad3bdca5d218eeb027e2ea8cc047d9c7265099fb09c0a85a03da350c8f319; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5c0","idBoard":"578e0353fb72eb74a29ac5ab","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:40 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac721/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924840283'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-6fe2ed31"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:40 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=cd847cecb46476b4385388efb61cfd15edcd1f330beafef644bf748aa8d55d9d; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:40 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5bc","idBoard":"578e0353fb72eb74a29ac5ab","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e0353fb72eb74a29ac5c7","idBoard":"578e0353fb72eb74a29ac5ab","name":"Pairing","color":"black","uses":34},{"id":"578e0353fb72eb74a29ac5c8","idBoard":"578e0353fb72eb74a29ac5ab","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:40 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac721/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924840510'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-6fe2ed31"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:40 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=6f48120aa174595ae2b7480f35e35ae2a856e3e51e74caf2a62290604839fed7; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:40 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5bc","idBoard":"578e0353fb72eb74a29ac5ab","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e0353fb72eb74a29ac5c7","idBoard":"578e0353fb72eb74a29ac5ab","name":"Pairing","color":"black","uses":34},{"id":"578e0353fb72eb74a29ac5c8","idBoard":"578e0353fb72eb74a29ac5ab","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:40 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac721/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924840870'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"f6VHc+BM4020A3hAFf5hug=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:40:40 GMT
-      Content-Length:
-      - '704'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VUTW8aMRD9K5ZzaSsW9otdsreU9JAqVSOR9NAkB689gJtd
-        e+UPUBrx3zsGFmiltI2E0Ho8fu/N+I1fqBS0ouNyAnE2Hs/rMoW6zFl6zniZ
-        JnRAayYWYGn1QlfahY94QFcS1lItvkBbg/mGYcSYs8bCgFpfW25kfRKa60Xt
-        Fz+RBuH4EvjTlYMWkdLT5TR8hVOIz3XbgnI7MuYc48vjWkAg6JzUilbOeGQQ
-        HmilfNNsThBnjm313j9isNH2RJHAnWtm3QV3ciXdM0pL46SI4jJKzm+TuMrD
-        bziJJ9/pjhAz7jrrDLCWdLKDRiqoyNK5zlajUcukGtbaLiMuh3wesa4bYg2j
-        PtOOwmalbSRbtoAH9aDOzsgF59A5pjgQLMiBkSzsfCC3SzBApCWMTK8OdMR4
-        pbDrxC2BfJ2RLRSpvWxEiGpFtDdkrs0TWUu33KbN7mafiMVmcGiaPfQRcHvW
-        Eo6t1XZAfO2V8wPClCDWW5S5L/6SObbr70mrBxSw7KZfSPFRM7PzUlkXUEAc
-        iyRLMlZMBP7FjIak7S030oa7vO9tV/xmu3OR0ceQe81qaPo8LoAnkxyKspyL
-        rJjM63GZI+QrW+PXt4o9OorYOZ9zXuZZmqRZmYmYi0zkab1VuzP43kNSzJba
-        4Jm0DIuLgy2negWm70PLlGfNNnTMOBiv6Ut6Oczda4X9V0MVayFYUwkwZI2u
-        NuFiw5jpRqMm+oz3rtcYwPtE3iTbDP5OPX4j9Q2TBu13Qlk3jD+9gbF4I+Ml
-        dID1YlePnJ03XQNH0njzeFSYZBV5l70nM3DEd2SqFcdJsSeDgENDtP1johCt
-        0wiW5XlcZPiyhdu/M+h42s89vgfY3u2o89Hz5x/X6+lNUOr/nTVKy6hLsiiL
-        LLjIdxHvZUW9rAhlRf2bER1kbX4BOcinkLQFAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:40 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac720/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924841119'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-20b03b07"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:41 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=f0d40aedbf68c823272f1a77d892c3c28f0a9f5c94594afee71ab10dbf09b5a8; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:41 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5bc","idBoard":"578e0353fb72eb74a29ac5ab","name":"Under
-        waterline","color":"yellow","uses":13},{"id":"578e0353fb72eb74a29ac5c7","idBoard":"578e0353fb72eb74a29ac5ab","name":"Pairing","color":"black","uses":33},{"id":"578e0353fb72eb74a29ac5c8","idBoard":"578e0353fb72eb74a29ac5ab","name":"Dependent","color":"purple","uses":3}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:41 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac720/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924841389'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-20b03b07"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:41 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=f6aa0ee310ce3e76425993f50c91b4863d0a2300c40655261b50803ca4caf4b8; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:41 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5bc","idBoard":"578e0353fb72eb74a29ac5ab","name":"Under
-        waterline","color":"yellow","uses":13},{"id":"578e0353fb72eb74a29ac5c7","idBoard":"578e0353fb72eb74a29ac5ab","name":"Pairing","color":"black","uses":33},{"id":"578e0353fb72eb74a29ac5c8","idBoard":"578e0353fb72eb74a29ac5ab","name":"Dependent","color":"purple","uses":3}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:41 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac720/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924841794'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"3ysb/Va/b5rKkvP50GlatQ=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:40:41 GMT
-      Content-Length:
-      - '709'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VU224aMRD9Fct5aSsW9sYu2beU5CFVqlYiqdRcHrz2wFpZ
-        bMv2gpKIf+8YskBVpW0khNbj8TnHM2f8QqWgFR2XE4iz8XhelynUZc7SU8bL
-        NKYDWjOxAEerF7rSPnzEA7qSsJZq8RWWNdgfGEaMOWsdDKjrasetrI9Cc72o
-        u8Uz0iAcb4A/XnpYIlJ6vJyGr3AK8bleLkH5HRnznvHmsBYQCIyXWtHK2w4Z
-        RAe0Ul3bbo4QZ55t9d49YLDV7kiRwJ0r5vwZ93Il/RNKS+OkiOIySk6vk7jK
-        8ZcMy6S4pTtCzLgxzltgS2KkgVYqqEjjvXHVaLRkUg1r7ZqIyyGfR8yYId5h
-        1Ge6kUNBHNo2UrCOBKwiXJt7da9OTsgZ52A8UxwIXsyDlSzsfCLXDVgg0hFG
-        ppd7WmI7pbD6xDdAelxSd7IVIaoV0Z0lc20fyVr6Zps2u5ld7HNfoQ+A27OO
-        cCyxdgPS1Z3y3YAwJYjrHAQs8s2AworyxyDttSjnzLNd3Y9aMKCA5Wj7hRSf
-        NbM7j5V1AQXEsUiyJGPFROBfzGhI2na/lS70+K63Y/GbHU9FQR9C7hWroe3z
-        uACeTHIoynIusmIyr8dljpBvbI3f3urRUcRuIjjnZZ6lSZqVmYi5yESe1lu1
-        O+O/ekuKWaMtnkknYXG2t+tUr8D2dVgy1bF2Gzpk7A3Z9ld62c/jWxf7r4Iq
-        toRgWSXAkjW63YZGh/HTrUZN9Al9oNcYwP4ib5JvBn+nHr+T+juTFu14RFm3
-        6J53MBbvZDwHtKgIVT1wms6aFg6kyebhoDDJK/Ih+0hm4ElnyFQrjpPjjgYj
-        GP+PCUM0oxEsK+I8L/HFC92/seh42r8H+E5gebdPAB9d/Lz9csXNc1Dx76xR
-        OolMkkdZ5MBHnYl4LyvqZUUoK9o/KHtZm1/p/90pzAUAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:41 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac722/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924842054'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-b38da53b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:42 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=a589469363b733959ca0cf9fe8fea40edc806eb1172a4f4e494e140f1629cbd9; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:42 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5bc","idBoard":"578e0353fb72eb74a29ac5ab","name":"Under
-        waterline","color":"yellow","uses":12},{"id":"578e0353fb72eb74a29ac5c7","idBoard":"578e0353fb72eb74a29ac5ab","name":"Pairing","color":"black","uses":32},{"id":"578e0353fb72eb74a29ac5c8","idBoard":"578e0353fb72eb74a29ac5ab","name":"Dependent","color":"purple","uses":2}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:42 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac722/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924842301'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-b38da53b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:42 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=b5c2d3fd92c51e8d0f776398b83a243ef08133115e9ac5cf00df648340d340bd; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:42 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5bc","idBoard":"578e0353fb72eb74a29ac5ab","name":"Under
-        waterline","color":"yellow","uses":12},{"id":"578e0353fb72eb74a29ac5c7","idBoard":"578e0353fb72eb74a29ac5ab","name":"Pairing","color":"black","uses":32},{"id":"578e0353fb72eb74a29ac5c8","idBoard":"578e0353fb72eb74a29ac5ab","name":"Dependent","color":"purple","uses":2}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:42 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac722/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924842661'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"+vizo/Sf8W2c/MYxNRttqg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:40:42 GMT
-      Content-Length:
-      - '667'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VUTW/bMAz9K4J22YY48UdsJ76l7Q4DUmBA2h3W9qAPJhFq
-        S4YkJ+iK/PdRSZykh24rYBgWSfE9ko9+pUrSiublBOIsz5e8TIGXY5ZOmSjT
-        lA4oZ3IFjlavdGN8+IgHdKNgq/TqFhoO9ieaMceS1Q4G1HXcCav4hWlpVrxb
-        /UYYTCfWIJ6/e2gwU3p5vA5f4RbmF6ZpQPsDGPOeifX5LCEAtF4ZTStvO0SQ
-        HdBKd3W9u8i48GzP9+EJjbVxF4wkeubM+ZnwaqP8C1JL46SI4jJKpndJXI3x
-        SYdFnP+iB0CMuG+dt8Aa0qoWaqWhImvvW1eNRg1TesiNW0dCDcUyYm07xBpG
-        faQbBWfFti7qeKd9F3Hm3aN+1J8+kZkQ0HqmBRCsy4NVLHi+krs1WCDKEXaC
-        JLbTGjtPrmZ37hjzxumCZ0GMJh49i/vFN+KwFwLq+lEfa7lhnh3addG5AQWs
-        ou4PSl4ZZg/SKHkBBcSxTLIkY8VE4itmNATth1YrF0bz0KuoeKOiqZzSpxA7
-        ZxzqPk5IEMlkDEVZLmVWTJY8L8eY8h1X/r6rOGZHEgchCyHKcZYmaVZmMhYy
-        k+OU79ke9HqUhJKLtbF4J52Gw+yksmuzAdv3oWG6Y/XedI446ajuS3o9rdF7
-        hf1XQzVrIChNS7BkiyK1Ya5ha0xtkBN9wTmaLRo6F6Sd5LvB36HzD0L/YMqi
-        vi4gec3E8wcQiw8i3kALWC929YzZdrat4Qya7p7ODJO8Ip+zL2QBnnQtuTZa
-        mM66iz1YGrtfEEzQGryflcUkS/DfFAZ+b1HktN9c3Gjs6H5ZxSi/jUsxf5kH
-        4H9HjdJp1CZ5lEUOfNS1keiZRD2TCJnsV53u/gBrAbezaQUAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:42 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac6ce/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924842916'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-d452f87f"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:42 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=df534cacec442f132219c11595a22b8ff4a76ecf69983a13fadcf26ff8c1e1fb; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:42 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5c0","idBoard":"578e0353fb72eb74a29ac5ab","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:42 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e0353fb72eb74a29ac5ab/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924843171'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"4yoUSUSYmVD4Luvn1wd//Q=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '298'
-      Date:
-      - Tue, 19 Jul 2016 10:40:43 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=9b758ea546da1225920568e1e92f6e616313f0d390e46f718243ea193cf50bcf; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:43 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1g7mRrlKVj1bHqAA6uUG2wjJOl6rvX
-        Q1VnCJF6zmrB0Sf8I96+SDyTA5HaBMolH7xmwWvhmHW9dD1pSXJT2FY8T/OS
-        r2EKaS3b137MJWw7BzeW0G5DjtktDyb5bc+cCzlwRmlLysWXfon+b8R3+1hy
-        3iWv8xLT2hxd/znmD4xFdEwALGG3nHJMKAJnWhmAYdgNL09YgP0/wNObQwhD
-        THGNOTV5aE45BSRIAwrx3e1fSaH5zUQJJMYoAIZVMByHMZQBMLyCYUgMB1we
-        LyqYDomxgFvkZQVDURhOGaQZdR8jLQ7DDKQZXcEYHEZbSDOmgtEojDAdpBlb
-        wSgURhkFacZVMBL1LFKr7jbz/gOkxgUfLwgAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:43 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e0353fb72eb74a29ac5ae/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924843658'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"xPjB+pA1T0/8ZF9KD9Hj/A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1453'
-      Date:
-      - Tue, 19 Jul 2016 10:40:43 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=faeae154971482af5983f6fcd29b2f6f4f387ae45be760c69c3e5f508c4e0984; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:43 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+1Xa2/bNhT9K4T6pQ1MW5IjOfa3NM2wAmmXwvGwtSlSirqy
-        2EikS1JxnSL/fZd62E6WtPXQrsWwIkApPu7j3HMP6TefPJF6Ey8aHYA/jIZZ
-        MgohGe2zcMx4xLnX83gO/PK5hXJqmQXjTWRVFDhdKAN4NGOFgZ6X4toJM/aQ
-        W3El7Apthn4QU39Eg/FZ4E+G40kQ9fdH0Wu0mYLhuKMdPWOWdWZF+lQx/XBI
-        LPHcphNh7MN7oN7zAsoEtPldWRfnm7dubporjQdDNz60lvG8BGmP1BXoLoKS
-        yYoV9dRmxzpPdM0SKBCGNw+B5nvoSrISMMBnTBQrMuW6KgmzJAhY2SOpYAUV
-        ckKeHU+IH49piP9o6EfjcY8cvZ6Q/dCnOBHR8QGNEMO4R06ZMVylgIvDAP8w
-        w4XCKEJ//8DvecbldSLkJfp8//LjcrYKD3FLwtK5K9kn70rVtcOtVwKWQs4b
-        dFpw2uRMlRiuRbI1lal5Us2vm2KtqdBY2nweuZE75WZV6RBrtrA1gs23K7cW
-        CyuU3FCnggb7m62xQ7q2WmClTVe+tqTNZ9EV4vMc9r2vZFVbsqkV/HLlslWF
-        QlZ4SVE5QlXGARj7N29buGe6wNXc2oWZDAZWQ1GoPmY/4IOtEtyDafXlg4OQ
-        po461DjqUGapow5tmUNToLd5Q/k1/Rtr6KIlDW05c9P7PFTjb97ucfwztHvw
-        b7X7GbByQlhaZRmi2CM8Rx+gcWBwiK2fuf+hmStZqTQrwOAQo5CqR8yVKgpm
-        8x6xOcKCNtZ9HsX+nT4PXp2cnA3/ZP/3+Q/r860S7Nbn3cFBQC1yhnaUoS1j
-        aEMYuuELXdOFNmyhHVnomitf6G8Iv2l/h0F/P9i+zs9yQFIbC5okmkmeE5Uh
-        kd0kz4UEvSIakM3CKhxyJkkCREhil4qYOprJuTyXe2Rv79xTC5Dn3t5ejyxz
-        kJ1dYYhbIJnSRMKSOHVDF1pV85yUoOfIeLLAjNDThwqQUqQxl2l1/YDBBOpD
-        GBrTkNamGR4vgBkgTKZEKqIwDY3tzCT2GcF9hGExl7gdwccMckQP7SpM3Blr
-        jdegamLV2iBLCmhyJY9FH/rODEHGaXoljHCL2z4QEWxbkqxIo1Lk1WEdkDt0
-        KdVSdmFSZB7SGXdgEzdnM/ER0id9B+jMQF2Gdy/YJZBa6t6RAkUEU8ckXHwG
-        bL2lDq0+9OjRI4KCiIyuXBcbN9dR2bU+TvWX4lKUgJdSX+n5wH0NfhEFTJ5z
-        uNCKpRdCXqDVi5fYRfkSk7k4A61d+QWYC8r67xfzH3cpxPfeCl4UhwfMP0jD
-        IM04j4LIZ9loP3I+H7grrK52vyrq9nMN0nCl0/nA9+NheFvos+ns+H28+OOn
-        E/rhHaFvgPgP6vxWBXbT+e7gALWz7i2qMtpW/K5aR7dyGAXZt32NjfrRONhS
-        a9ffnMPColKj7GBbghasEWCn5E5np7PpMTkBtkBhgJJjYrVgVqKwTri5kpY5
-        YUfJMaShAgLjljo05sLmVdKgUagqzVQlU70aJMrkDioYNGjUE7Tz0sWQKl45
-        rjHHL/cD6h6zLsbbtmshOtLg4GaSdolQl8jaBUWdp09/m/7qMqoWDsLUKaGG
-        rABu6yRTp+W38mwDQ31try9GzAI4Pss3m+obZI1ebQefeIWSc7zrdUnmitUw
-        ojMhLcy1E4IlJlQrcKOtzTFczzTCoytuK12rRbXAT3wxnMsfJ5zR8Hu+p0fo
-        //6lhG/p52kQTsjj+Al5WiO14ed2uTpVHQ3jYXRHVa85f/Fhdjz9vqoa3auq
-        4S7P511UtUMuvoXcmKfeP9bb0Y56e8qEewPdElxW/5BpFHcYfOGZmvAdPc5k
-        il23xDbS+KqBLc8rJ8XLtesg+Bqx3yLGbmLfHRxgh9BFENKY1m280Rz86b5F
-        zpu3fwFe4m8HfxMAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:43 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0353fb72eb74a29ac5cc/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924843914'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-d452f87f"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:43 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=dac757f1fcc046c490cc2c66087587002790a71e3b2b42b7a020ef2079ff2e34; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:43 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5c0","idBoard":"578e0353fb72eb74a29ac5ab","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:43 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0353fb72eb74a29ac5c9/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924844152'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-d452f87f"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=d1cf48ebd7ee5b1b385cc4ad0aa283f52688548bc33cb237808fee338123848b; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:44 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5c0","idBoard":"578e0353fb72eb74a29ac5ab","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0353fb72eb74a29ac5e2/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924844422'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-d452f87f"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=9652d928864b6614028fec553f8cc3a7ca7497d34edc7229cd602aa84013d061; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:44 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5c0","idBoard":"578e0353fb72eb74a29ac5ab","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac71f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924844681'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-9d344ebf"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=98d9ec6bccdf1b581e01f9f88bf4d854effd42f9e2956775117070ed32d26ff9; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:44 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5bc","idBoard":"578e0353fb72eb74a29ac5ab","name":"Under
-        waterline","color":"yellow","uses":11},{"id":"578e0353fb72eb74a29ac5c7","idBoard":"578e0353fb72eb74a29ac5ab","name":"Pairing","color":"black","uses":31}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac71f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924844965'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-9d344ebf"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:40:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=93a1b55fc078f86ac6e4611d8a83b2ebffb35acb1b526d129b369915dd93fcc4; Path=/;
-        Expires=Fri, 22 Jul 2016 10:40:44 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e0353fb72eb74a29ac5bc","idBoard":"578e0353fb72eb74a29ac5ab","name":"Under
-        waterline","color":"yellow","uses":11},{"id":"578e0353fb72eb74a29ac5c7","idBoard":"578e0353fb72eb74a29ac5ab","name":"Pairing","color":"black","uses":31}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:45 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578e0355fb72eb74a29ac71f/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578ccc743212373d0cd3d42b
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924845305'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"lahR9xUF9dZUaH/VVoZUNg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Tue, 19 Jul 2016 10:40:45 GMT
-      Content-Length:
-      - '775'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VUXU/cMBD8K5Z5aasL+bokcG9AK7USqJUO+tDCg2Nv7iwc
-        O7UdToD4710nhAtSUVvpdIrt3Z2Z9awfqRR0RYvqCJK8KJq6yqCuliw7ZrxK
-        G7qgNRMbcHT1SO+MDx/Jgt5J2Em9uYC2Bvsdt7FGw5SDBXV97biV9WyrMZu6
-        3zwgDJbjW+C3Xzy0WKmYL8/CV8jKcNe0LWg/gjHvGd/u1wICQOel0XTlbY8I
-        oge60r1ST7OKa88Gvj8fUePZtLsXW74Se8wB2bmQgyFIoFOAn0+Lf8sWyR+z
-        b5CPMm7WDIEh58z5E+7lnfT3GJ4laRklVZQeX6bJaom/4jArlj/oqBUjDg7I
-        CefQeaY5EFTvwUp2ra/1B3K5BWI60Our9SdyDqwjDolyUIpIR+peKk+kJtxo
-        z6QG6whzZOwhXlI42nrfuVUcb6Tf9vUhso+RdC8a02th7+PauG3sLUDcInGw
-        w0Y0oUwchOF9uCQWLoYw/6eygePr2jt5K+MzC9iViOloEhIFIS8QUWNsdPp1
-        /Tko6rvQQkG8IRYaBdwPIgX68bXOZ2IWG8Y0qYEw4jrgkql9EMHK++4NddyC
-        KKM3EQptycawoY0IJrWHjUVoskNBxKPkYFPUOqTheWOxPbbnvkdM0yBTXAJr
-        r/XzTX5kno0+nVl2QaFlUk0LKU4Ns+NMVnUJJSSJSPM0Z+WRwL+E0cXkSCVd
-        mImfbzla0JsQe85qUFMcF8DToyWUVdWIvDxq6qJaYsk3jornEog0ep9zXi3z
-        LM3yKhcJF7lYZvVAaXwNAs6Qst4aizl5EhYnLzN8Zu7ATmJbpnumhq19xMuo
-        qIn348sj9Rb7f+qaZm2Yzist8OJ3eJNWoQfCm2SUQU70Hr1mdrjRu/BwpOU4
-        /W9DF/8J/Y1Jiz6dQdaK8ds54s0+OM1W5F35npwO/tpP9dzkmNoZzMyP8U7w
-        PXWh61cW7USn+UMPoqxxrOMHzi9+XX1aB8i/R8V5EnVpFpXR4PH9QEodzTg8
-        /Qa72Sf8RgYAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:40:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/GVMQz9dx?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924964958'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '3'
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"iQn3s0zKiGrq1oOgZhDZTg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '639'
-      Date:
-      - Tue, 19 Jul 2016 10:42:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=3a8e709cb8b3f695b9938ab86a6482bc3b819f908503d59e562b9a6e5d3c7b19; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:44 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VUy27bMBD8FYKnFjCsOC87vuXVIkWSJrXTU4CAFFcyIWqp
-        Lim5TpB/71Kxa6c59GJAw33N7KxfpDVyKo/GE9g7KI7U8RGMJ8VImcnJKB8d
-        yIFEVQNHzCHEM6/I7DNmIOSMXWEEQuWETg+i8CQiqbyyWIqlp0pYFBFULU5d
-        QWCGj/iIn+YJqG0I1uNU3KgKhI0CVLBAfQmnqAQBqXZDNkAQ0QtqUcyuL2di
-        tN9XXYAwKiphyHaAQq9E3oboa66BACY8ys/D9aAXHCen2Do3kLnzAZhwoVyA
-        AXP/TqVC+6wiT8OMDmG8V2g9OTjMIR+PtFF7Wh2bnEs1FnEntSXH8YsYmzDN
-        skjgnB/mvs509vXnzf3zifmdRdZMbzQLC0/x4f9ZqRVBEeT0RTZAa6WuoYOU
-        6qnkgM5H1pg/jQ1KOx6Lqfm6ZtE4T9ZQa6DAoMXOxp7cezyAK755y5Qjtcwm
-        5yHPfZced5DT8q1LY0lFSD2UAzSKvrDEl/jWeSOI5sWX5FtMfmpaiqunpffm
-        icMruft8VasSdlQw+9WoiGU3brz+NR7yilpTkMc4RIiZTdEh26aH7J/iwwbL
-        jw1maVaz2fv2cW4dbDhu0TOy5SIihCTTh4nPvfP010IKz+Cu1c7mW60YYie9
-        +75jZybVtthVWsYaeB1IpzS4W76uftUlASQH3ib3ivtTHmCV3LFk7AEN+3rJ
-        1chZTIvwpLAXce6FBkHQWVj2NqBEel0FYSnYIXwZyULJWC01ib68gIYXyXZJ
-        PF2boFm0ebVK3uDfqfwBjm8y9XK2/wN4O4GqH6dxqj+GlMwqMXanLCWzvL7+
-        AblHupRSBAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924965185'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '267'
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '786'
-      Etag:
-      - W/"312-bf1f7f02"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=1d9f48a707ae00ccd4d5f169626f53312730fe86d270f78fdb0c9d90db648de7; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:45 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"TestBoard","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/testboard","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
-        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e03f5a65e78f1ad891c13/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924965467'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"11E6Ek3ZF1MTDuYY2Qln7A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '297'
-      Date:
-      - Tue, 19 Jul 2016 10:42:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=29dcb976b7ef1f11e9938459725daa116af7039a34dc54efbd75ee80b478aa78; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:45 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1wMbdsjbJkrDpWHbANFaoNlnG7VH33
-        eqjqDCHDOasFR5/wj3j9JnEkJyK18VQE6ZT02gTmRmPZwDrSkuRmv6+4zsua
-        v/zs01b2r8OUi993BjcV3+5DztmtDyaJfc+SCzkJTmlLymdfhjX2/yN+2scS
-        eUheljWmrTm74WPK7xhLx3gHsKjDcskxoQiCa2UABn0Ynp+wAAsAmJtD8CGm
-        uMWcmhyaS04eCdKQQuztX0m++ctEdUiMUQCMq2AEDmMoB2D6CoYjMQJyeYYK
-        hiExFnKLxgqGojCCckgz/j5GWhyGG0gzoYIxOIy2gGY4rWA0CtMZBmiGswpG
-        oTDKKEAznFcwEvUsUqvuNvP2Cxy3CV4vCAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e03f5a65e78f1ad891c15/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924965838'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"44rFQdEllyYvjoyBnFX2nw=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1677'
-      Date:
-      - Tue, 19 Jul 2016 10:42:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=24ffa44d118973d444fa7dc1008ec78c85171528edf17f1720044c82ca0b0014; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:45 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+2ZfXObRhCHv8oNnWmbjg8Bd7zpP8VOG3fs2o3spG2SyRxw
-        WFcjINxh1cm4n717SEjIVixrItduE3lGFnCvu799doHXHw2RGH3D9QNukdRj
-        nsv9ILVZEoR24sfGjhGPeHy+r/h4qJji0ujndZbB6ayQHLqmLJN8x0jg2gGT
-        ahArcSHUJYzpWLaHLR/b4Ylt9anddwMz8Jw/YMyEyxhazH7tMcXaYUXytGBV
-        Z0nu0pJimxi60YGQ6tNt3KbNIR9HvJIvC6XX+fqtPjccFRV0tD1LHw2UYvFo
-        zHO1W1zwql3DmOU1y5pTixbzncLkLOIZGOL1J+Z3AgMmy9mYwxKHZSVyhTza
-        R77pmwgjO4D/sMKygDEcYlJKSOB6tutQj/g7htRrPBD5OfR+Fb1KFf31GTSP
-        WHKmzf/RuCgaP8AWLgSfiPxsutPZRmfLlHUk40pEnVNpcRbVZx+mhp+7dTrS
-        4nBX/9K99NlirPc+bcLmtpgea9dVolSiyBcyqPnUiled39pmzagZeE22rpi5
-        Z3qYtSZd1uNNw95RIa3xlYjPL/Vui6wA/xpRBovaMWqpDehZV29n5j6tMrg6
-        UqqU/V5PVTzLChN234t7HRessGm9vmMP1IZlIwPsUezDnx1g37jauT34oq0H
-        n+s9iuBzw38r+H4qWNZHh0Kxc7aDWAKDKiE5OoRxRc6rSwQO4wzOfIsmlVAc
-        iVwqlmVMqxqd1SLhKC0qtPtjG7DUM4PA833bIRYNHZ8uB+wl+f3F+5Pow9eA
-        fbCA7bhgs4BtO/ZAofgMpIPHjXLwXDh43AoHz4SDG9ngrmxwIxsMssFxui7K
-        abLdKA9Nyw06Uf7NN2gQx7xULI85ivViK8He5G/yH9C++k6ipIhrLRGeoFEx
-        QapAVZ0jNeLogmUC5gT1QygMT4fPkLyUWnC67wk0aLtOg0VICKaUVxwmShD0
-        KlmlUJE2Y9WlBFOz8XKfh0MQ8baBoAVojt0++t55gvZm2+vaMk5xUXItkPgc
-        3zBqyxWb+sR0Aps6NKCea1nOMlj2n0/2ToMD737B4q4Ei30bWOxrYFFVfWeu
-        tA70lxyY8hCWteqSYzmRcQuM7kCHjh03o0PbsQfiwaWLHdxqGYOzsSowOBuv
-        djYGKkhg2Doa2N62aRAQ2qGBjlqlw3DEJNIuFUoHPggVDsqMQwLU0Sq09xGL
-        IALgGAJ7ApNVGYDPbAI/hgiVCGwOImcVRzq2VTxCmpnSfLiodoKVUQ0DOmGS
-        xh61XC8ILBo7Dg89Rxt7q+XG32j69woN0Al6hl6gA7SPfoFfsyvzqj8IQ9Pz
-        PcuHWHdcy/eWg/1wsP8n8U7DR1dFfE6w/6eKiI4HNsNE27EHasQTzLDCHFc4
-        wwLneC0AfGvrRT+xOgA4bfNwKUquA7qP2l2MmcjNqJAjHAsTMMbKstlS21L2
-        9MV+IbEYszOuS4jbigvgBJAB2MHQ7v58Op0Qc5Bug5mjIWqGQlEtskSfhZxY
-        1JWuuM/RRKhR02xaeoA5YjBzW3vMB2z6AsxAn4XcQXVU56qGWj9PkCbumwcs
-        Mlz3Pu9z0kWOvHaJWJ+85NAOro5tAlULeYKGXEGFhnaLPAbzy4519b1PIa+5
-        qaWYb1HqmyTwKHVDG9C6DLGfn1fiL+sov1+IOZ9/K/TZFQuUJc5tZcnteEs3
-        xNsxE9XUCwu+QbUxBxyh1yGzSh+bzLjHoaRJtD4Xc5Z1BQXDfNJ1c4LwNpvz
-        FCasFoVHZ+ZLTdvJfGab3oXnHTFuxvO2I9wUuri0CSZYcoXrEsdtuOA2XJp7
-        vhaQeB4ua5jvpVtnvkO3xfyWuzjnE5zwCwzH5RbY3457n+xv6HUE0h3qalwv
-        7QFzAX3suYDeJRfccFubCwLbt1yTEPhPQH7utcdi5JjtZtH77IvIBe7XXPCo
-        c0FHjJvlgrYj5AIKuYCuzQVzet41F/j29ut/b6v1P5tIPAUtjpiSG6SCG3ng
-        6eBE3mA6XJT6ylAnhBUp4AERvpVnhveJcPcuCNdWn1PbJ4SaxKYW8X0/CK+9
-        fQyJYAP75fkXQe3gK7UfNbU7YtyM2m1HoLYH1HbXUltzbe2T2m2+t3H6lmXS
-        8HG8nXVWv52dPURNnJgSz0r9JOAh82gSbfsh6jv9QUP0DA3QU/jeQ+9mn5Za
-        oRN6+l1JGFq2BtgytEYfjkhY/yYf/bPT/+8b2I4LNgvVtmMPVIgl5pjhCL4T
-        4+rtP68gXieqJAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7c/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924966093'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=c5aa6563e3d81b35f671d01cf61f5de31bbe204137f7e4666d1b79bddc596404; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7b/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924966383'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=2e166cc982e5943ebd204df3d99d6426cd86bbc25435ed64ea442786ece2eea5; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924966617'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=0020475cfd930e492a9b00ea9e7787a7671ba40462a78f280d3202a999aa49a3; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924966888'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '675'
-      Etag:
-      - W/"2a3-854cbdcb"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=b18f04b5c012a682d70651da0ae3bea5f618c4ef955423def6817ecd6215f8a6; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"577b6e7368b58e244f1ebc06","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":65535,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"577b6f351f72355ef16a9074","name":"Sprint
-        Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":262143,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924967120'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=1c2e0b96cb9f0a78db95445eb778a62deeffaeb8caa5cf15ec3baad38ad2ecc2; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:47 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d16/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924967402'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=069832c3ed9565899220dd011c766f90323a8f5b9cdf9ef144118c1ef99935d8; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:47 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924967690'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=1f9a4fee4591258ce04a0c791fb99407a87b959483e349fdd96f1ac31c4d7fb8; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:47 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924967962'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=efb246c0d4b79bd6359a4dcfeeaa44dfa029e43bda496b879e6c063af6e50f1d; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924968234'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=a2ba975c86407c53cb184205e1f300c3441aa39cfc5eb0c4a2a034eb6e924946; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:48 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924968506'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=ec3fffa9a0df939cb9561d403bd52b5493f50b605310871674afad93c413fcd2; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:48 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d71/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924968802'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=237c3cc7f17a89a9d12af17bdf84bba04b7d86fb46aae303941067ddfae77727; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:48 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d71/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924969058'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=5b3cf33633ffc6859c9ce07b74763ca3fa34729c160db4b058e333bf3f26a074; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:49 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:49 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d1d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924969325'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=be6110d9ffb9e6c37c75c0e5bc9eca629ca8c7ae93387d5ee5c51826e5ca18b8; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:49 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:49 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e03f5a65e78f1ad891c13/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924969602'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"11E6Ek3ZF1MTDuYY2Qln7A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '297'
-      Date:
-      - Tue, 19 Jul 2016 10:42:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=7834b04fd675e59f875d11ff3089f19135a3198bdc8fb4c0d5d0edbdee0e6945; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:49 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1wMbdsjbJkrDpWHbANFaoNlnG7VH33
-        eqjqDCHDOasFR5/wj3j9JnEkJyK18VQE6ZT02gTmRmPZwDrSkuRmv6+4zsua
-        v/zs01b2r8OUi993BjcV3+5DztmtDyaJfc+SCzkJTmlLymdfhjX2/yN+2scS
-        eUheljWmrTm74WPK7xhLx3gHsKjDcskxoQiCa2UABn0Ynp+wAAsAmJtD8CGm
-        uMWcmhyaS04eCdKQQuztX0m++ctEdUiMUQCMq2AEDmMoB2D6CoYjMQJyeYYK
-        hiExFnKLxgqGojCCckgz/j5GWhyGG0gzoYIxOIy2gGY4rWA0CtMZBmiGswpG
-        oTDKKEAznFcwEvUsUqvuNvP2Cxy3CV4vCAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:49 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e03f5a65e78f1ad891c16/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924969888'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"QE9sWUvdVC44Mxfbk4LU1w=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1454'
-      Date:
-      - Tue, 19 Jul 2016 10:42:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=1f9987720cf3737f72a19ce96b3ff0de2240f20e1915eb71c886b1260daa80a3; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:49 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+1Xa3PTOBT9KxrzBTpRYjux8/hWCgy7U1iYtPuAMkW2r2NR
-        WzKSnGxg+t/3yo88ui2QHViYnWU6g6zHfZx77pHy+qPDE2fmBOMJuMM0YGEA
-        40nqsWQy9eLh0Ok5cQbx1U8GirlhBrQzE1We43QuNeDRlOUaek6Ca6dMm+PY
-        8CU3a7Tpu15I3TH1pmeeOxt5s2Dcn3jTV2gzAR3jjnb0iBnWmeXJQ8nU3SF5
-        NiSenHJt7t4T1nueQRGB0r9KY+N8/cbOzTOp8KBvx8fGsDgrQJgTuQTVRVAw
-        UbG8ntru2OSJrlkEOcLw+g7v/sRBV4IVgAE+Yjxfk3msqoIwQzyPFT2ScJZT
-        Lmbk0eMZccMp9fEf9d1gOu2Rk1czMvJdihMBnU5ogBiGPfKCaR3LBHBx6OEf
-        ZlhKjMJ3RxO352ib1ykXV+jzj8fPxfFTwXFLxJKFLdlHZynr2uHWJYcVF4sG
-        nRacNjldRTpWPNqZSuUiqhYfmmJtqNBY2n6e2JE9ZWdlYRFrtrANgs23Lbfi
-        peFSbKlTQYP99c7YIl1bzbHSuitfW9LmM+8K8UkOYzm+kFVtyeaGx1drm63M
-        JbLCiXIMqudU2gIYutdvWrjPVY6rmTGlng0GRkGeyz5mP4gHOyW4BdPq8wcH
-        Pk0sdai21KHMUEsd2jKHJkD3eUPjD/RvrKFlSxracua69+l2975+u/s/Qrt7
-        /1a7nwErZoQlVZoiij0SZ+gDFA40DrH1U/s/NHMFK6RiOWgcYhRC9oheyjxn
-        JusRkyEsaGPT50Ho3ujzd8WT5e/ypfd/n3+3Pt8pwWF93h0ceNQgZ2hHGdoy
-        hjaEoVu+0A1daMMW2pGFbrjymf4efc3r3J+5fj/c6++zDJDU2oAikWIizohM
-        kch2Ms64ALUmCpDN3EgcxkyQCAgXxKwk0XU0swtxIY7I0dGFI0sQF87RUY+s
-        MhCdXa6JXSCpVETAilh1QxdKVouMFKAWyHhSYkbo6X0FSCnSmEuV/HCHwQjq
-        QxgaU5DUphkez4FpIEwkREgiMQ2F7cwE9hnBfYRhMVe4HcHHDDJED+1KTNwa
-        a43XoCpi5MYgi3JociX3eR/61gxBxim65JrbxV0fiAi2LYnWpFEp8vK4Dsge
-        uhJyJbowKTIP6Yw7sImbsyn/E5IHfQvouYa6DG+fsSsgtdS9JTmKCKaOSdj4
-        NJh6Sx1afejevXsEBREZXdku1nauo7JtfZzqr/gVLwAvpb5Ui4H9GjzhOcx+
-        iuFSSZZccnGJVi+fYxdlK0zm8gyUsuXnoC8p678rF9/vUghvvRWcIPQnzJ0k
-        vpekcRx4gcvS8SiInDvvCqOqw6+Kuv1sgzRc6XTec91w6O8L/WkCwyp6f/zD
-        Cf3whtA3QPwHdX6nAofpfHdwgNpZ9xaVKW0rflOtw70ckhC+7mtsgq+x8Y5a
-        2/6OYygNKjXKDrYlKM4aAbZKbnV2fj5/TE6BlSgMUMSYWC2YFc+NFe5YCsOs
-        sKPkaNJQAYGxSx0aC26yKmrQyGWVpLISiVoPIqkzCxUMGjTqCdp56WJIZFxZ
-        rjHLL/sD6hazNsZ927UQnSiwcDNBu0SoTWTjgqLO04e/zJ/ajKrSQphYJVSQ
-        5hCbOsnEavlenm1gqK/t9cWILiHGZ/l2U32DbNCr7eATL5digXe9KshCshpG
-        dMaFgYWyQrDChGoFbrS1OYbrqUJ4VBWbStVqUZX4iS+GC/H9hDMYfsv3dIr+
-        71ga7ejnC8+fkfvhA/KwRmrLz91ydao6HobD4IaqvvqtPB/9/Hz4bVU1uFVV
-        /UOez4eoaofceBc51ILY+cd6mx6oty8Yt2+gPcFl9Q+ZRnGHo888U7HMh3k8
-        Fwl23QrbSOGrBnY8r60UrzauvdGXiP0OMQ4T++7gADuElp5PQ1q38VZz8Kf7
-        Djmv3/wFh9pjiH8TAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:49 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c33/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924970133'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:50 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=65258b1f393b5fd460f9e64524d4d8761262a6385236a6c4e58f032532de47a2; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:50 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:50 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c31/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924970405'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:50 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=dc8f453d0268866c46474c63ccf37e4c343982947b520cce6fba243a4d5db460; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:50 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:50 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c43/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924970734'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:50 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=37df5dad3c7a3df7e39033513c463cba7ae6388e9741cd1ef0e2f5c7423c3cce; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:50 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:50 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6e/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924970972'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-8d75582c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:51 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=583aa2a45b4615e9b3bdadd8498ee893ae23d57ee81518f7f28090cab3d44198; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:50 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:51 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6e/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468924971240'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-8d75582c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:42:51 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=374a75ac3f963b283a9221aa581f2ca57f9a6e20ec61ebd5295cf20c4e04b7ac; Path=/;
-        Expires=Fri, 22 Jul 2016 10:42:51 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:42:51 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/GVMQz9dx?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925025250'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '3'
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"iQn3s0zKiGrq1oOgZhDZTg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '639'
-      Date:
-      - Tue, 19 Jul 2016 10:43:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=f800b8e81f34a848beeba93a5343661e838491db03ce36224ee75d347ef4343e; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:45 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VUy27bMBD8FYKnFjCsOC87vuXVIkWSJrXTU4CAFFcyIWqp
-        Lim5TpB/71Kxa6c59GJAw33N7KxfpDVyKo/GE9g7KI7U8RGMJ8VImcnJKB8d
-        yIFEVQNHzCHEM6/I7DNmIOSMXWEEQuWETg+i8CQiqbyyWIqlp0pYFBFULU5d
-        QWCGj/iIn+YJqG0I1uNU3KgKhI0CVLBAfQmnqAQBqXZDNkAQ0QtqUcyuL2di
-        tN9XXYAwKiphyHaAQq9E3oboa66BACY8ys/D9aAXHCen2Do3kLnzAZhwoVyA
-        AXP/TqVC+6wiT8OMDmG8V2g9OTjMIR+PtFF7Wh2bnEs1FnEntSXH8YsYmzDN
-        skjgnB/mvs509vXnzf3zifmdRdZMbzQLC0/x4f9ZqRVBEeT0RTZAa6WuoYOU
-        6qnkgM5H1pg/jQ1KOx6Lqfm6ZtE4T9ZQa6DAoMXOxp7cezyAK755y5Qjtcwm
-        5yHPfZced5DT8q1LY0lFSD2UAzSKvrDEl/jWeSOI5sWX5FtMfmpaiqunpffm
-        icMruft8VasSdlQw+9WoiGU3brz+NR7yilpTkMc4RIiZTdEh26aH7J/iwwbL
-        jw1maVaz2fv2cW4dbDhu0TOy5SIihCTTh4nPvfP010IKz+Cu1c7mW60YYie9
-        +75jZybVtthVWsYaeB1IpzS4W76uftUlASQH3ib3ivtTHmCV3LFk7AEN+3rJ
-        1chZTIvwpLAXce6FBkHQWVj2NqBEel0FYSnYIXwZyULJWC01ib68gIYXyXZJ
-        PF2boFm0ebVK3uDfqfwBjm8y9XK2/wN4O4GqH6dxqj+GlMwqMXanLCWzvL7+
-        AblHupRSBAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925025496'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '267'
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '786'
-      Etag:
-      - W/"312-bf1f7f02"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=9717cd75ea3781383549a1e7ae15adce46b32bd962aca5c7b7a3121d9258e9d7; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:45 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"TestBoard","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/testboard","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
-        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e03f5a65e78f1ad891c13/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925025806'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"11E6Ek3ZF1MTDuYY2Qln7A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '297'
-      Date:
-      - Tue, 19 Jul 2016 10:43:45 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=dc58af75daf69a87a8cc925fa8252655a5b86035afe7cbc534445f8147bec556; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:45 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1wMbdsjbJkrDpWHbANFaoNlnG7VH33
-        eqjqDCHDOasFR5/wj3j9JnEkJyK18VQE6ZT02gTmRmPZwDrSkuRmv6+4zsua
-        v/zs01b2r8OUi993BjcV3+5DztmtDyaJfc+SCzkJTmlLymdfhjX2/yN+2scS
-        eUheljWmrTm74WPK7xhLx3gHsKjDcskxoQiCa2UABn0Ynp+wAAsAmJtD8CGm
-        uMWcmhyaS04eCdKQQuztX0m++ctEdUiMUQCMq2AEDmMoB2D6CoYjMQJyeYYK
-        hiExFnKLxgqGojCCckgz/j5GWhyGG0gzoYIxOIy2gGY4rWA0CtMZBmiGswpG
-        oTDKKEAznFcwEvUsUqvuNvP2Cxy3CV4vCAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:45 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e03f5a65e78f1ad891c15/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925026187'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"44rFQdEllyYvjoyBnFX2nw=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1677'
-      Date:
-      - Tue, 19 Jul 2016 10:43:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e2d7c3d7f0e1d0ad66881ba4a01a3c5ce636db04e65582a89eeef388c076303e; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:46 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+2ZfXObRhCHv8oNnWmbjg8Bd7zpP8VOG3fs2o3spG2SyRxw
-        WFcjINxh1cm4n717SEjIVixrItduE3lGFnCvu799doHXHw2RGH3D9QNukdRj
-        nsv9ILVZEoR24sfGjhGPeHy+r/h4qJji0ujndZbB6ayQHLqmLJN8x0jg2gGT
-        ahArcSHUJYzpWLaHLR/b4Ylt9anddwMz8Jw/YMyEyxhazH7tMcXaYUXytGBV
-        Z0nu0pJimxi60YGQ6tNt3KbNIR9HvJIvC6XX+fqtPjccFRV0tD1LHw2UYvFo
-        zHO1W1zwql3DmOU1y5pTixbzncLkLOIZGOL1J+Z3AgMmy9mYwxKHZSVyhTza
-        R77pmwgjO4D/sMKygDEcYlJKSOB6tutQj/g7htRrPBD5OfR+Fb1KFf31GTSP
-        WHKmzf/RuCgaP8AWLgSfiPxsutPZRmfLlHUk40pEnVNpcRbVZx+mhp+7dTrS
-        4nBX/9K99NlirPc+bcLmtpgea9dVolSiyBcyqPnUiled39pmzagZeE22rpi5
-        Z3qYtSZd1uNNw95RIa3xlYjPL/Vui6wA/xpRBovaMWqpDehZV29n5j6tMrg6
-        UqqU/V5PVTzLChN234t7HRessGm9vmMP1IZlIwPsUezDnx1g37jauT34oq0H
-        n+s9iuBzw38r+H4qWNZHh0Kxc7aDWAKDKiE5OoRxRc6rSwQO4wzOfIsmlVAc
-        iVwqlmVMqxqd1SLhKC0qtPtjG7DUM4PA833bIRYNHZ8uB+wl+f3F+5Pow9eA
-        fbCA7bhgs4BtO/ZAofgMpIPHjXLwXDh43AoHz4SDG9ngrmxwIxsMssFxui7K
-        abLdKA9Nyw06Uf7NN2gQx7xULI85ivViK8He5G/yH9C++k6ipIhrLRGeoFEx
-        QapAVZ0jNeLogmUC5gT1QygMT4fPkLyUWnC67wk0aLtOg0VICKaUVxwmShD0
-        KlmlUJE2Y9WlBFOz8XKfh0MQ8baBoAVojt0++t55gvZm2+vaMk5xUXItkPgc
-        3zBqyxWb+sR0Aps6NKCea1nOMlj2n0/2ToMD737B4q4Ei30bWOxrYFFVfWeu
-        tA70lxyY8hCWteqSYzmRcQuM7kCHjh03o0PbsQfiwaWLHdxqGYOzsSowOBuv
-        djYGKkhg2Doa2N62aRAQ2qGBjlqlw3DEJNIuFUoHPggVDsqMQwLU0Sq09xGL
-        IALgGAJ7ApNVGYDPbAI/hgiVCGwOImcVRzq2VTxCmpnSfLiodoKVUQ0DOmGS
-        xh61XC8ILBo7Dg89Rxt7q+XG32j69woN0Al6hl6gA7SPfoFfsyvzqj8IQ9Pz
-        PcuHWHdcy/eWg/1wsP8n8U7DR1dFfE6w/6eKiI4HNsNE27EHasQTzLDCHFc4
-        wwLneC0AfGvrRT+xOgA4bfNwKUquA7qP2l2MmcjNqJAjHAsTMMbKstlS21L2
-        9MV+IbEYszOuS4jbigvgBJAB2MHQ7v58Op0Qc5Bug5mjIWqGQlEtskSfhZxY
-        1JWuuM/RRKhR02xaeoA5YjBzW3vMB2z6AsxAn4XcQXVU56qGWj9PkCbumwcs
-        Mlz3Pu9z0kWOvHaJWJ+85NAOro5tAlULeYKGXEGFhnaLPAbzy4519b1PIa+5
-        qaWYb1HqmyTwKHVDG9C6DLGfn1fiL+sov1+IOZ9/K/TZFQuUJc5tZcnteEs3
-        xNsxE9XUCwu+QbUxBxyh1yGzSh+bzLjHoaRJtD4Xc5Z1BQXDfNJ1c4LwNpvz
-        FCasFoVHZ+ZLTdvJfGab3oXnHTFuxvO2I9wUuri0CSZYcoXrEsdtuOA2XJp7
-        vhaQeB4ua5jvpVtnvkO3xfyWuzjnE5zwCwzH5RbY3457n+xv6HUE0h3qalwv
-        7QFzAX3suYDeJRfccFubCwLbt1yTEPhPQH7utcdi5JjtZtH77IvIBe7XXPCo
-        c0FHjJvlgrYj5AIKuYCuzQVzet41F/j29ut/b6v1P5tIPAUtjpiSG6SCG3ng
-        6eBE3mA6XJT6ylAnhBUp4AERvpVnhveJcPcuCNdWn1PbJ4SaxKYW8X0/CK+9
-        fQyJYAP75fkXQe3gK7UfNbU7YtyM2m1HoLYH1HbXUltzbe2T2m2+t3H6lmXS
-        8HG8nXVWv52dPURNnJgSz0r9JOAh82gSbfsh6jv9QUP0DA3QU/jeQ+9mn5Za
-        oRN6+l1JGFq2BtgytEYfjkhY/yYf/bPT/+8b2I4LNgvVtmMPVIgl5pjhCL4T
-        4+rtP68gXieqJAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7c/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925026426'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=06a491d9f57572b3447bb1c324dbe91239ec5700cb11a0535299b16a69ec8569; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7b/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925026696'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=665e4472c5cb82fbb7fb411c73b34be3a75cb8ab43851333783297d8a57e32eb; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925026939'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=6ee7ae30dbe1cc9c5e18db0f761c1128a04503c0c1af4f9d6c55534007ad5777; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:47 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925027192'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '675'
-      Etag:
-      - W/"2a3-854cbdcb"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=b76442308ec51ac8fff8ac73aa53ef9f324a802fc34b42ed132228f7a5ae1e10; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"577b6e7368b58e244f1ebc06","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":65535,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"577b6f351f72355ef16a9074","name":"Sprint
-        Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":262143,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:47 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925027423'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=78846f724d929498b3f8cb477ccd1ba1d1c4c41d752f678d713eda7c1a27356b; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:47 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d16/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925027711'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=6d5958cbfb07fdd0ae02ce93b9b9947b9d78ea36c07a8a25fbb09d4cd8beaa35; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:47 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925027956'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:47 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=349a12ce69e4a0751c9a49a81b16963abb216389d19a5ee81d190ea5da77c649; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:47 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925028216'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:43:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=ee3b742d06608173c474d4aa7e8d83c8c0625238a61ca319994fb3339a562f9b; Path=/;
-        Expires=Fri, 22 Jul 2016 10:43:48 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:43:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/GVMQz9dx?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925042348'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '3'
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"iQn3s0zKiGrq1oOgZhDZTg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '639'
-      Date:
-      - Tue, 19 Jul 2016 10:44:02 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=b5852d8e99ed34f5e84e76f42dd891528a68ea1d0ad19582dc75f0bf3dc8961a; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:02 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VUy27bMBD8FYKnFjCsOC87vuXVIkWSJrXTU4CAFFcyIWqp
-        Lim5TpB/71Kxa6c59GJAw33N7KxfpDVyKo/GE9g7KI7U8RGMJ8VImcnJKB8d
-        yIFEVQNHzCHEM6/I7DNmIOSMXWEEQuWETg+i8CQiqbyyWIqlp0pYFBFULU5d
-        QWCGj/iIn+YJqG0I1uNU3KgKhI0CVLBAfQmnqAQBqXZDNkAQ0QtqUcyuL2di
-        tN9XXYAwKiphyHaAQq9E3oboa66BACY8ys/D9aAXHCen2Do3kLnzAZhwoVyA
-        AXP/TqVC+6wiT8OMDmG8V2g9OTjMIR+PtFF7Wh2bnEs1FnEntSXH8YsYmzDN
-        skjgnB/mvs509vXnzf3zifmdRdZMbzQLC0/x4f9ZqRVBEeT0RTZAa6WuoYOU
-        6qnkgM5H1pg/jQ1KOx6Lqfm6ZtE4T9ZQa6DAoMXOxp7cezyAK755y5Qjtcwm
-        5yHPfZced5DT8q1LY0lFSD2UAzSKvrDEl/jWeSOI5sWX5FtMfmpaiqunpffm
-        icMruft8VasSdlQw+9WoiGU3brz+NR7yilpTkMc4RIiZTdEh26aH7J/iwwbL
-        jw1maVaz2fv2cW4dbDhu0TOy5SIihCTTh4nPvfP010IKz+Cu1c7mW60YYie9
-        +75jZybVtthVWsYaeB1IpzS4W76uftUlASQH3ib3ivtTHmCV3LFk7AEN+3rJ
-        1chZTIvwpLAXce6FBkHQWVj2NqBEel0FYSnYIXwZyULJWC01ib68gIYXyXZJ
-        PF2boFm0ebVK3uDfqfwBjm8y9XK2/wN4O4GqH6dxqj+GlMwqMXanLCWzvL7+
-        AblHupRSBAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:02 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925042601'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '267'
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '786'
-      Etag:
-      - W/"312-bf1f7f02"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:02 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=7aadb4b63d044f2b851fedd0fb7c91772fadda6c85c5e285025788087d715c87; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:02 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"TestBoard","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/testboard","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
-        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:02 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e03f5a65e78f1ad891c13/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925042935'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"11E6Ek3ZF1MTDuYY2Qln7A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '297'
-      Date:
-      - Tue, 19 Jul 2016 10:44:02 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=28fd90be1337a63d87f8bafd9f420912db69716d2aa88a44ba617d9c562325cc; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:02 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1wMbdsjbJkrDpWHbANFaoNlnG7VH33
-        eqjqDCHDOasFR5/wj3j9JnEkJyK18VQE6ZT02gTmRmPZwDrSkuRmv6+4zsua
-        v/zs01b2r8OUi993BjcV3+5DztmtDyaJfc+SCzkJTmlLymdfhjX2/yN+2scS
-        eUheljWmrTm74WPK7xhLx3gHsKjDcskxoQiCa2UABn0Ynp+wAAsAmJtD8CGm
-        uMWcmhyaS04eCdKQQuztX0m++ctEdUiMUQCMq2AEDmMoB2D6CoYjMQJyeYYK
-        hiExFnKLxgqGojCCckgz/j5GWhyGG0gzoYIxOIy2gGY4rWA0CtMZBmiGswpG
-        oTDKKEAznFcwEvUsUqvuNvP2Cxy3CV4vCAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:02 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e03f5a65e78f1ad891c15/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925043330'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"44rFQdEllyYvjoyBnFX2nw=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1677'
-      Date:
-      - Tue, 19 Jul 2016 10:44:03 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=b4d65ac7f3dbbf851ad93102f6f422e7699f213de85d51f94098189f4ee2a37b; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:03 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+2ZfXObRhCHv8oNnWmbjg8Bd7zpP8VOG3fs2o3spG2SyRxw
-        WFcjINxh1cm4n717SEjIVixrItduE3lGFnCvu799doHXHw2RGH3D9QNukdRj
-        nsv9ILVZEoR24sfGjhGPeHy+r/h4qJji0ujndZbB6ayQHLqmLJN8x0jg2gGT
-        ahArcSHUJYzpWLaHLR/b4Ylt9anddwMz8Jw/YMyEyxhazH7tMcXaYUXytGBV
-        Z0nu0pJimxi60YGQ6tNt3KbNIR9HvJIvC6XX+fqtPjccFRV0tD1LHw2UYvFo
-        zHO1W1zwql3DmOU1y5pTixbzncLkLOIZGOL1J+Z3AgMmy9mYwxKHZSVyhTza
-        R77pmwgjO4D/sMKygDEcYlJKSOB6tutQj/g7htRrPBD5OfR+Fb1KFf31GTSP
-        WHKmzf/RuCgaP8AWLgSfiPxsutPZRmfLlHUk40pEnVNpcRbVZx+mhp+7dTrS
-        4nBX/9K99NlirPc+bcLmtpgea9dVolSiyBcyqPnUiled39pmzagZeE22rpi5
-        Z3qYtSZd1uNNw95RIa3xlYjPL/Vui6wA/xpRBovaMWqpDehZV29n5j6tMrg6
-        UqqU/V5PVTzLChN234t7HRessGm9vmMP1IZlIwPsUezDnx1g37jauT34oq0H
-        n+s9iuBzw38r+H4qWNZHh0Kxc7aDWAKDKiE5OoRxRc6rSwQO4wzOfIsmlVAc
-        iVwqlmVMqxqd1SLhKC0qtPtjG7DUM4PA833bIRYNHZ8uB+wl+f3F+5Pow9eA
-        fbCA7bhgs4BtO/ZAofgMpIPHjXLwXDh43AoHz4SDG9ngrmxwIxsMssFxui7K
-        abLdKA9Nyw06Uf7NN2gQx7xULI85ivViK8He5G/yH9C++k6ipIhrLRGeoFEx
-        QapAVZ0jNeLogmUC5gT1QygMT4fPkLyUWnC67wk0aLtOg0VICKaUVxwmShD0
-        KlmlUJE2Y9WlBFOz8XKfh0MQ8baBoAVojt0++t55gvZm2+vaMk5xUXItkPgc
-        3zBqyxWb+sR0Aps6NKCea1nOMlj2n0/2ToMD737B4q4Ei30bWOxrYFFVfWeu
-        tA70lxyY8hCWteqSYzmRcQuM7kCHjh03o0PbsQfiwaWLHdxqGYOzsSowOBuv
-        djYGKkhg2Doa2N62aRAQ2qGBjlqlw3DEJNIuFUoHPggVDsqMQwLU0Sq09xGL
-        IALgGAJ7ApNVGYDPbAI/hgiVCGwOImcVRzq2VTxCmpnSfLiodoKVUQ0DOmGS
-        xh61XC8ILBo7Dg89Rxt7q+XG32j69woN0Al6hl6gA7SPfoFfsyvzqj8IQ9Pz
-        PcuHWHdcy/eWg/1wsP8n8U7DR1dFfE6w/6eKiI4HNsNE27EHasQTzLDCHFc4
-        wwLneC0AfGvrRT+xOgA4bfNwKUquA7qP2l2MmcjNqJAjHAsTMMbKstlS21L2
-        9MV+IbEYszOuS4jbigvgBJAB2MHQ7v58Op0Qc5Bug5mjIWqGQlEtskSfhZxY
-        1JWuuM/RRKhR02xaeoA5YjBzW3vMB2z6AsxAn4XcQXVU56qGWj9PkCbumwcs
-        Mlz3Pu9z0kWOvHaJWJ+85NAOro5tAlULeYKGXEGFhnaLPAbzy4519b1PIa+5
-        qaWYb1HqmyTwKHVDG9C6DLGfn1fiL+sov1+IOZ9/K/TZFQuUJc5tZcnteEs3
-        xNsxE9XUCwu+QbUxBxyh1yGzSh+bzLjHoaRJtD4Xc5Z1BQXDfNJ1c4LwNpvz
-        FCasFoVHZ+ZLTdvJfGab3oXnHTFuxvO2I9wUuri0CSZYcoXrEsdtuOA2XJp7
-        vhaQeB4ua5jvpVtnvkO3xfyWuzjnE5zwCwzH5RbY3457n+xv6HUE0h3qalwv
-        7QFzAX3suYDeJRfccFubCwLbt1yTEPhPQH7utcdi5JjtZtH77IvIBe7XXPCo
-        c0FHjJvlgrYj5AIKuYCuzQVzet41F/j29ut/b6v1P5tIPAUtjpiSG6SCG3ng
-        6eBE3mA6XJT6ylAnhBUp4AERvpVnhveJcPcuCNdWn1PbJ4SaxKYW8X0/CK+9
-        fQyJYAP75fkXQe3gK7UfNbU7YtyM2m1HoLYH1HbXUltzbe2T2m2+t3H6lmXS
-        8HG8nXVWv52dPURNnJgSz0r9JOAh82gSbfsh6jv9QUP0DA3QU/jeQ+9mn5Za
-        oRN6+l1JGFq2BtgytEYfjkhY/yYf/bPT/+8b2I4LNgvVtmMPVIgl5pjhCL4T
-        4+rtP68gXieqJAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:03 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7c/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925043587'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:03 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=6b9e99a1ad38031f33db8ef2706d3d33b5765b788bf4260afdfb74ac811f44b8; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:03 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:03 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7b/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925043873'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:03 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=7714bb4052b3cddd8c92a18a0ee2120d7076d5b41f2218f111f5b8cc30f5e36e; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:03 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:03 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925044161'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:04 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=713ddbffca104d0549eb533cdd25dfc55da393c0e192286c545370d984280262; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:04 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:04 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925044411'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '675'
-      Etag:
-      - W/"2a3-854cbdcb"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:04 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e9222bc00a03c6e1bc31d98e6f2a93fd9252ef2ce5fba2b4411556f0ee0c88a5; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:04 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"577b6e7368b58e244f1ebc06","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":65535,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"577b6f351f72355ef16a9074","name":"Sprint
-        Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":262143,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:04 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925044673'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:04 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e29583885429ce9a6b3a50a8eccecbb6007514a38571b2984b20970e2edf18d7; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:04 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:04 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d16/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925044918'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:04 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=75c251cfb93a786a0992be74dc45f68af390928c8ae69d76236dadc2a7cd8d42; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:04 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:04 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925045179'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:05 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=ae35575919df8ef3fb88ab3a710bf8020d5fb61951a6c2b680a1901e7ba7c555; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:05 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:05 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925045408'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:05 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=a96a654fcfe51fc7e1b5d66a1dea24bf7f3c3dfc05d301282681b7dc6b15caeb; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:05 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:05 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925045673'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:05 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=5f29d1ab068d9815681113722f5f2c1f82cbf35b19cc41e875a144277e31688c; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:05 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:05 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925045936'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:05 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e39a1bce9c3d3bb45f1fbd020dbc164b1588c3a7b723a88b410d85ecee963143; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:05 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:05 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d71/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925046198'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:06 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=5679cc46e15befbfc4e0dc15c12797a7c4904241042d35bac9f0fd732217b0d0; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:06 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:06 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d71/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925046487'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:06 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=ee87fe68fdc1b27584f8022eba39955060e0c0e35b60fad2bc91b4a82c206bc4; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:06 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:06 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d1d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925046779'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:06 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=2a718cc9cfc8c29949b71be1cfc4e4b11b9b2348bbc679091237c2e6b8b54ac6; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:06 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:06 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e03f5a65e78f1ad891c13/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925047066'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"11E6Ek3ZF1MTDuYY2Qln7A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '297'
-      Date:
-      - Tue, 19 Jul 2016 10:44:07 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=d90837b96053895a4ce6e59e67cb731803a7a13f1f902877eb91f879660dbf58; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:07 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1wMbdsjbJkrDpWHbANFaoNlnG7VH33
-        eqjqDCHDOasFR5/wj3j9JnEkJyK18VQE6ZT02gTmRmPZwDrSkuRmv6+4zsua
-        v/zs01b2r8OUi993BjcV3+5DztmtDyaJfc+SCzkJTmlLymdfhjX2/yN+2scS
-        eUheljWmrTm74WPK7xhLx3gHsKjDcskxoQiCa2UABn0Ynp+wAAsAmJtD8CGm
-        uMWcmhyaS04eCdKQQuztX0m++ctEdUiMUQCMq2AEDmMoB2D6CoYjMQJyeYYK
-        hiExFnKLxgqGojCCckgz/j5GWhyGG0gzoYIxOIy2gGY4rWA0CtMZBmiGswpG
-        oTDKKEAznFcwEvUsUqvuNvP2Cxy3CV4vCAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:07 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e03f5a65e78f1ad891c16/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925047378'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"QE9sWUvdVC44Mxfbk4LU1w=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1454'
-      Date:
-      - Tue, 19 Jul 2016 10:44:07 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=3cd4d52c38d9c658a7110be1fa9f003a4398a29a9aaa68ad9e85da91ef7ecb19; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:07 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+1Xa3PTOBT9KxrzBTpRYjux8/hWCgy7U1iYtPuAMkW2r2NR
-        WzKSnGxg+t/3yo88ui2QHViYnWU6g6zHfZx77pHy+qPDE2fmBOMJuMM0YGEA
-        40nqsWQy9eLh0Ok5cQbx1U8GirlhBrQzE1We43QuNeDRlOUaek6Ca6dMm+PY
-        8CU3a7Tpu15I3TH1pmeeOxt5s2Dcn3jTV2gzAR3jjnb0iBnWmeXJQ8nU3SF5
-        NiSenHJt7t4T1nueQRGB0r9KY+N8/cbOzTOp8KBvx8fGsDgrQJgTuQTVRVAw
-        UbG8ntru2OSJrlkEOcLw+g7v/sRBV4IVgAE+Yjxfk3msqoIwQzyPFT2ScJZT
-        Lmbk0eMZccMp9fEf9d1gOu2Rk1czMvJdihMBnU5ogBiGPfKCaR3LBHBx6OEf
-        ZlhKjMJ3RxO352ib1ykXV+jzj8fPxfFTwXFLxJKFLdlHZynr2uHWJYcVF4sG
-        nRacNjldRTpWPNqZSuUiqhYfmmJtqNBY2n6e2JE9ZWdlYRFrtrANgs23Lbfi
-        peFSbKlTQYP99c7YIl1bzbHSuitfW9LmM+8K8UkOYzm+kFVtyeaGx1drm63M
-        JbLCiXIMqudU2gIYutdvWrjPVY6rmTGlng0GRkGeyz5mP4gHOyW4BdPq8wcH
-        Pk0sdai21KHMUEsd2jKHJkD3eUPjD/RvrKFlSxracua69+l2975+u/s/Qrt7
-        /1a7nwErZoQlVZoiij0SZ+gDFA40DrH1U/s/NHMFK6RiOWgcYhRC9oheyjxn
-        JusRkyEsaGPT50Ho3ujzd8WT5e/ypfd/n3+3Pt8pwWF93h0ceNQgZ2hHGdoy
-        hjaEoVu+0A1daMMW2pGFbrjymf4efc3r3J+5fj/c6++zDJDU2oAikWIizohM
-        kch2Ms64ALUmCpDN3EgcxkyQCAgXxKwk0XU0swtxIY7I0dGFI0sQF87RUY+s
-        MhCdXa6JXSCpVETAilh1QxdKVouMFKAWyHhSYkbo6X0FSCnSmEuV/HCHwQjq
-        QxgaU5DUphkez4FpIEwkREgiMQ2F7cwE9hnBfYRhMVe4HcHHDDJED+1KTNwa
-        a43XoCpi5MYgi3JociX3eR/61gxBxim65JrbxV0fiAi2LYnWpFEp8vK4Dsge
-        uhJyJbowKTIP6Yw7sImbsyn/E5IHfQvouYa6DG+fsSsgtdS9JTmKCKaOSdj4
-        NJh6Sx1afejevXsEBREZXdku1nauo7JtfZzqr/gVLwAvpb5Ui4H9GjzhOcx+
-        iuFSSZZccnGJVi+fYxdlK0zm8gyUsuXnoC8p678rF9/vUghvvRWcIPQnzJ0k
-        vpekcRx4gcvS8SiInDvvCqOqw6+Kuv1sgzRc6XTec91w6O8L/WkCwyp6f/zD
-        Cf3whtA3QPwHdX6nAofpfHdwgNpZ9xaVKW0rflOtw70ckhC+7mtsgq+x8Y5a
-        2/6OYygNKjXKDrYlKM4aAbZKbnV2fj5/TE6BlSgMUMSYWC2YFc+NFe5YCsOs
-        sKPkaNJQAYGxSx0aC26yKmrQyGWVpLISiVoPIqkzCxUMGjTqCdp56WJIZFxZ
-        rjHLL/sD6hazNsZ927UQnSiwcDNBu0SoTWTjgqLO04e/zJ/ajKrSQphYJVSQ
-        5hCbOsnEavlenm1gqK/t9cWILiHGZ/l2U32DbNCr7eATL5digXe9KshCshpG
-        dMaFgYWyQrDChGoFbrS1OYbrqUJ4VBWbStVqUZX4iS+GC/H9hDMYfsv3dIr+
-        71ga7ejnC8+fkfvhA/KwRmrLz91ydao6HobD4IaqvvqtPB/9/Hz4bVU1uFVV
-        /UOez4eoaofceBc51ILY+cd6mx6oty8Yt2+gPcFl9Q+ZRnGHo888U7HMh3k8
-        Fwl23QrbSOGrBnY8r60UrzauvdGXiP0OMQ4T++7gADuElp5PQ1q38VZz8Kf7
-        Djmv3/wFh9pjiH8TAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:07 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c33/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925047634'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:07 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=0d2b390aae32ea0ce677bffb3ba959462f69f8f8194e6327633d9a8adc9dec9f; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:07 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:07 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c31/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925047905'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:07 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=35be8decad2276b3824b74d28129c000506c39570f3814e85b6ad7677602bd02; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:07 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:07 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c43/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925048146'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:08 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=c8e3ee140173442f58d89c94783b944bc9e300005204b4f580873c5f892fea1c; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:08 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:08 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6e/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925048391'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-8d75582c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:08 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=caff642d0b9e19e95a4b2035959dcb183e4a516c106366a7a744076463f3a545; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:08 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:08 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6e/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925048650'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-8d75582c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:08 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=b6d81cd07b8c0c18e2f567105c2ba34b954fe0f9afdc3a6756fdb60133ecda66; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:08 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:08 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/GVMQz9dx?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925064614'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '3'
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"iQn3s0zKiGrq1oOgZhDZTg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '639'
-      Date:
-      - Tue, 19 Jul 2016 10:44:24 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e8fec030b98cfedb1cdacf9f6ee0086ef580c29d7ed5b73de286fa526582c02c; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:24 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VUy27bMBD8FYKnFjCsOC87vuXVIkWSJrXTU4CAFFcyIWqp
-        Lim5TpB/71Kxa6c59GJAw33N7KxfpDVyKo/GE9g7KI7U8RGMJ8VImcnJKB8d
-        yIFEVQNHzCHEM6/I7DNmIOSMXWEEQuWETg+i8CQiqbyyWIqlp0pYFBFULU5d
-        QWCGj/iIn+YJqG0I1uNU3KgKhI0CVLBAfQmnqAQBqXZDNkAQ0QtqUcyuL2di
-        tN9XXYAwKiphyHaAQq9E3oboa66BACY8ys/D9aAXHCen2Do3kLnzAZhwoVyA
-        AXP/TqVC+6wiT8OMDmG8V2g9OTjMIR+PtFF7Wh2bnEs1FnEntSXH8YsYmzDN
-        skjgnB/mvs509vXnzf3zifmdRdZMbzQLC0/x4f9ZqRVBEeT0RTZAa6WuoYOU
-        6qnkgM5H1pg/jQ1KOx6Lqfm6ZtE4T9ZQa6DAoMXOxp7cezyAK755y5Qjtcwm
-        5yHPfZced5DT8q1LY0lFSD2UAzSKvrDEl/jWeSOI5sWX5FtMfmpaiqunpffm
-        icMruft8VasSdlQw+9WoiGU3brz+NR7yilpTkMc4RIiZTdEh26aH7J/iwwbL
-        jw1maVaz2fv2cW4dbDhu0TOy5SIihCTTh4nPvfP010IKz+Cu1c7mW60YYie9
-        +75jZybVtthVWsYaeB1IpzS4W76uftUlASQH3ib3ivtTHmCV3LFk7AEN+3rJ
-        1chZTIvwpLAXce6FBkHQWVj2NqBEel0FYSnYIXwZyULJWC01ib68gIYXyXZJ
-        PF2boFm0ebVK3uDfqfwBjm8y9XK2/wN4O4GqH6dxqj+GlMwqMXanLCWzvL7+
-        AblHupRSBAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:24 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925064873'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '267'
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '786'
-      Etag:
-      - W/"312-bf1f7f02"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:24 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=8719a51dae662d6cba083529d2d6e181c66dde91bd548d35c76f657d0e258ebf; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:24 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"TestBoard","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/testboard","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
-        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:24 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e03f5a65e78f1ad891c13/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925065168'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"11E6Ek3ZF1MTDuYY2Qln7A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '297'
-      Date:
-      - Tue, 19 Jul 2016 10:44:25 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=2163483c25fb3a2b5cd08331eacff8bc256a0693be1d72d55390c8f10460e3b4; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:25 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1wMbdsjbJkrDpWHbANFaoNlnG7VH33
-        eqjqDCHDOasFR5/wj3j9JnEkJyK18VQE6ZT02gTmRmPZwDrSkuRmv6+4zsua
-        v/zs01b2r8OUi993BjcV3+5DztmtDyaJfc+SCzkJTmlLymdfhjX2/yN+2scS
-        eUheljWmrTm74WPK7xhLx3gHsKjDcskxoQiCa2UABn0Ynp+wAAsAmJtD8CGm
-        uMWcmhyaS04eCdKQQuztX0m++ctEdUiMUQCMq2AEDmMoB2D6CoYjMQJyeYYK
-        hiExFnKLxgqGojCCckgz/j5GWhyGG0gzoYIxOIy2gGY4rWA0CtMZBmiGswpG
-        oTDKKEAznFcwEvUsUqvuNvP2Cxy3CV4vCAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:25 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e03f5a65e78f1ad891c15/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925065566'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"44rFQdEllyYvjoyBnFX2nw=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1677'
-      Date:
-      - Tue, 19 Jul 2016 10:44:25 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=5db08db2b444a6acd78af60ae92975def7f7f7276d42b826a08651d384328b72; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:25 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+2ZfXObRhCHv8oNnWmbjg8Bd7zpP8VOG3fs2o3spG2SyRxw
-        WFcjINxh1cm4n717SEjIVixrItduE3lGFnCvu799doHXHw2RGH3D9QNukdRj
-        nsv9ILVZEoR24sfGjhGPeHy+r/h4qJji0ujndZbB6ayQHLqmLJN8x0jg2gGT
-        ahArcSHUJYzpWLaHLR/b4Ylt9anddwMz8Jw/YMyEyxhazH7tMcXaYUXytGBV
-        Z0nu0pJimxi60YGQ6tNt3KbNIR9HvJIvC6XX+fqtPjccFRV0tD1LHw2UYvFo
-        zHO1W1zwql3DmOU1y5pTixbzncLkLOIZGOL1J+Z3AgMmy9mYwxKHZSVyhTza
-        R77pmwgjO4D/sMKygDEcYlJKSOB6tutQj/g7htRrPBD5OfR+Fb1KFf31GTSP
-        WHKmzf/RuCgaP8AWLgSfiPxsutPZRmfLlHUk40pEnVNpcRbVZx+mhp+7dTrS
-        4nBX/9K99NlirPc+bcLmtpgea9dVolSiyBcyqPnUiled39pmzagZeE22rpi5
-        Z3qYtSZd1uNNw95RIa3xlYjPL/Vui6wA/xpRBovaMWqpDehZV29n5j6tMrg6
-        UqqU/V5PVTzLChN234t7HRessGm9vmMP1IZlIwPsUezDnx1g37jauT34oq0H
-        n+s9iuBzw38r+H4qWNZHh0Kxc7aDWAKDKiE5OoRxRc6rSwQO4wzOfIsmlVAc
-        iVwqlmVMqxqd1SLhKC0qtPtjG7DUM4PA833bIRYNHZ8uB+wl+f3F+5Pow9eA
-        fbCA7bhgs4BtO/ZAofgMpIPHjXLwXDh43AoHz4SDG9ngrmxwIxsMssFxui7K
-        abLdKA9Nyw06Uf7NN2gQx7xULI85ivViK8He5G/yH9C++k6ipIhrLRGeoFEx
-        QapAVZ0jNeLogmUC5gT1QygMT4fPkLyUWnC67wk0aLtOg0VICKaUVxwmShD0
-        KlmlUJE2Y9WlBFOz8XKfh0MQ8baBoAVojt0++t55gvZm2+vaMk5xUXItkPgc
-        3zBqyxWb+sR0Aps6NKCea1nOMlj2n0/2ToMD737B4q4Ei30bWOxrYFFVfWeu
-        tA70lxyY8hCWteqSYzmRcQuM7kCHjh03o0PbsQfiwaWLHdxqGYOzsSowOBuv
-        djYGKkhg2Doa2N62aRAQ2qGBjlqlw3DEJNIuFUoHPggVDsqMQwLU0Sq09xGL
-        IALgGAJ7ApNVGYDPbAI/hgiVCGwOImcVRzq2VTxCmpnSfLiodoKVUQ0DOmGS
-        xh61XC8ILBo7Dg89Rxt7q+XG32j69woN0Al6hl6gA7SPfoFfsyvzqj8IQ9Pz
-        PcuHWHdcy/eWg/1wsP8n8U7DR1dFfE6w/6eKiI4HNsNE27EHasQTzLDCHFc4
-        wwLneC0AfGvrRT+xOgA4bfNwKUquA7qP2l2MmcjNqJAjHAsTMMbKstlS21L2
-        9MV+IbEYszOuS4jbigvgBJAB2MHQ7v58Op0Qc5Bug5mjIWqGQlEtskSfhZxY
-        1JWuuM/RRKhR02xaeoA5YjBzW3vMB2z6AsxAn4XcQXVU56qGWj9PkCbumwcs
-        Mlz3Pu9z0kWOvHaJWJ+85NAOro5tAlULeYKGXEGFhnaLPAbzy4519b1PIa+5
-        qaWYb1HqmyTwKHVDG9C6DLGfn1fiL+sov1+IOZ9/K/TZFQuUJc5tZcnteEs3
-        xNsxE9XUCwu+QbUxBxyh1yGzSh+bzLjHoaRJtD4Xc5Z1BQXDfNJ1c4LwNpvz
-        FCasFoVHZ+ZLTdvJfGab3oXnHTFuxvO2I9wUuri0CSZYcoXrEsdtuOA2XJp7
-        vhaQeB4ua5jvpVtnvkO3xfyWuzjnE5zwCwzH5RbY3457n+xv6HUE0h3qalwv
-        7QFzAX3suYDeJRfccFubCwLbt1yTEPhPQH7utcdi5JjtZtH77IvIBe7XXPCo
-        c0FHjJvlgrYj5AIKuYCuzQVzet41F/j29ut/b6v1P5tIPAUtjpiSG6SCG3ng
-        6eBE3mA6XJT6ylAnhBUp4AERvpVnhveJcPcuCNdWn1PbJ4SaxKYW8X0/CK+9
-        fQyJYAP75fkXQe3gK7UfNbU7YtyM2m1HoLYH1HbXUltzbe2T2m2+t3H6lmXS
-        8HG8nXVWv52dPURNnJgSz0r9JOAh82gSbfsh6jv9QUP0DA3QU/jeQ+9mn5Za
-        oRN6+l1JGFq2BtgytEYfjkhY/yYf/bPT/+8b2I4LNgvVtmMPVIgl5pjhCL4T
-        4+rtP68gXieqJAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:25 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7c/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925065874'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:25 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=a0c0e781797ff022c7c3f203e78ff5258d72036f7f2a9caf07137483518d1a70; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:25 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:25 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7b/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925066156'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:26 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=63332e659623cedb9372625d47711b71b8594c98670231a874b949b5a2d86f3c; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:26 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:26 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925066416'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:26 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e22fe25b16a8fe1ed885723ebf11601673701f461011a62658ab5289a4e6a833; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:26 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:26 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925066689'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '675'
-      Etag:
-      - W/"2a3-854cbdcb"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:26 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=635f9ed7817b85a0e6acc31f14a2b4767c13a34ef6e3d702514195722fb9414a; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:26 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"577b6e7368b58e244f1ebc06","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":65535,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"577b6f351f72355ef16a9074","name":"Sprint
-        Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":262143,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:26 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925066933'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:26 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e31e19a5bbb530a38301b50159e16ae76dba717831b98fa3cd6c308336de8dac; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:26 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:26 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d4d/idBoard?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb12/idBoard?key=mykey&token=mytoken
     body:
       encoding: UTF-8
       string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
@@ -8734,7 +677,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -8744,44 +687,50 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925067285'
+      - '1481203116969'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"yi//D+xlmQRrTrEEzFZhqA=="
+      - W/"BCSI1EUOqbV1NorUSfTvrA=="
       Vary:
       - Accept-Encoding
       Content-Encoding:
       - gzip
       Date:
-      - Tue, 19 Jul 2016 10:44:27 GMT
+      - Thu, 08 Dec 2016 13:18:37 GMT
       Content-Length:
-      - '571'
+      - '814'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4VSy27bMBD8FYI59AEz1sOWHN1cp0ADpEABJz00yYEiVzYR
-        ihRIykFq5N+79CsKmqIXgbvanZ2dnS1VklZ0Ws4gyZuCF1MoZ03K5ewilRNJ
-        R7TmcgWeVlu6sSE+khHdKHhSZvUd2hrcT0wjRsO1hxH1fe2FU/Ug1dhV3a9+
-        4xiEE2sQj1cBWkSaDsNFfMWuFLO2bcGE/TAeAhfrQ4w/JcQBXVDW0Cq4HifI
-        Hmhleq1fBojLwHd877a44+KYfV22fLNsAxzZ+diDJUig04DPlwdE1NYP1pFY
-        cs19mIugNio8Y3mWpAVLSpZe3KRJNZlUWXmeTbJfdM8WK87OyFwI6AI3Agjy
-        D+AUvzf35jO5Ch88kVb0cUeQZG2fSLDE9YaENZAN1wpnWkesIcvb5Vfin31U
-        LPbeYMGxlUdJiPLEQQMOcJAk2NVxF4htdlh954MD3r7tOdC85IHvZRwoOqLQ
-        cqWPgZJfLHd7y5R1AQUkiUzzNOfFTOIniSoe5NbKx5Pd/UvwCyx971eWZDV9
-        iDDXvAYdIfYR4p3OJ5o0maTTvE6KRIisrOVu8N6Sp5bl2jrsydMYzE9GWtgN
-        uONKLTc917vUa8Xp2npAwfA2muPHtCIfs0/k8qDh8GCiYbYDgz4Sj+yvyyHF
-        zkYXF/lsgm6L7G4dikvXIXS+Go/xOlrbc/TfWIyvvj1d3s6uC2zr/181zlPW
-        TVnGjrdlyIsFy5AXe58Xs4b53qPN/wANKOdFCAQAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:27 GMT
+        H4sIAAAAAAAAA41US3PbNhD+KxjkEnfMiBRN6nFT5EumSeqpkxwS+wACSwkj
+        EGBBQKrr8X/vLijZOsSTXCQA3O+xu1g8cq34klfzq0XV1M0V5M2iqusZ/jdN
+        MeWXvBFqAwNfPvK9C7TIL/lew0HbzSfoGvDf8Bg5WmEGuORDbAbpdXN21LpN
+        Ezf/oQzSyS3I3YcAHTLV59s1rQiF/NJ1HdgwiokQhNy+7BWQQB+0s3wZfEQF
+        FYEvbTQmLdeu6w0EOBp4OlO5DSLl8OMeD40bzlwq/PJRDGElg97r8IB2p3lR
+        Z8U0y+dfinJZzJdl/W6Rz77z0QRGvHnDVlJCH4SVwNBWAK/Fnb2zf7BPOoid
+        YHpgPlqL5WLOsrAFZuHAtsKrg/CIcbbVm+gF5UOwa3ewQXdAQOmcV9qiM8UO
+        OmwTfH3zgQUQ3RgsI1UmoQkRe8pD0bf1OTN9Cx4SkyBiBQn/+ZYdnN8NrHU+
+        sSvojXvAqOFhwIIxYRVh1VFopF4Zw4QPuhUyYHrwT9QeIcQx4imUUXo9+EEj
+        kQ3mgYm90EY0BlKkh947FSVV5kU5IfVYqDaG6JPP29UNubAONTWl0LgYTnza
+        YLuYaxOm1z0YbYF6gN35THeW1u+No+vFIhbXsANgB/bARMqeHJypI9PYuzt7
+        7PS1COLsgr1+1y45dOjpFKDVe4eNpgGbzZoaashzVZRFKeq5wp9ccApKV99g
+        mehmvjKLU+D3FPtRNGBe4pSQ8yuoZ7NWlbVoFqqqjnFIl3TnkJeyLfKroiqb
+        vM6lnM4alXTH+T2Og1a3W+cRUywK2q2ex27t9uBPKXXCRmHS0UvEc/bm5O7x
+        7F35mcffrI0VHZaWH5s3uYYerCJBeiOMQ1e8jx47gAdxoMkunu6fYTflkr2t
+        LtjfMHaX7SwO13PL/0IyfBDk7jSqOCbwL06wFQYnbAinGXgrhdnHYbIHE7sL
+        lOodKk2ni3KGT9hAZfvqsel8G0I/LCcTnDRj3Dt8xiZy4nv4s1rEG7L466gJ
+        lj/ry6zK/NF1llxnR9eZQ9cDuc665DpzNju5zsh1NrrORtNZMs2f/geSQ5cc
+        6QUAAA==
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:37 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d16/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb11/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -8808,7 +757,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -8818,32 +767,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925067566'
+      - '1481203117241'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '113'
+      - '2'
       Etag:
-      - W/"71-f4b7b51d"
+      - W/"2-d4cbb29"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:44:27 GMT
+      - Thu, 08 Dec 2016 13:18:37 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=61c90caa68854ee9c82d7f1ee15ad505cf3a5e23e0612138f6f39eb5ca769e04; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:27 GMT; Secure
+      - dsc=dc262ec11b72e8465f6a11e79f296cc295e930758b15d36ffad27ab8eb995028; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:37 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:27 GMT
+      string: "[]"
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:37 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb11/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -8870,7 +819,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -8880,846 +829,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925067873'
+      - '1481203117501'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '354'
+      - '2'
       Etag:
-      - W/"162-702e3496"
+      - W/"2-d4cbb29"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:44:27 GMT
+      - Thu, 08 Dec 2016 13:18:37 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=8b7109d513ce95e3e52da062063c161aeafbb2d7f7aeb87593d5d79c76fc07a9; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:27 GMT; Secure
+      - dsc=85fb89df34876f8563f3d9c731374016c3b7367f71c9db0af8501eedcbc375f3; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:37 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:27 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925068127'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:44:28 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=c9d0c60eb66700fc2d6a2b3f5675a5e062ad0b571862ee4e0c98c2ecca0f9db3; Path=/;
-        Expires=Fri, 22 Jul 2016 10:44:28 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:44:28 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/GVMQz9dx?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925114400'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '5'
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"iQn3s0zKiGrq1oOgZhDZTg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '639'
-      Date:
-      - Tue, 19 Jul 2016 10:45:14 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=0ee18eb96eef455b17518711c9ff0a5595220a9c4535f9e394debda8c9ed7200; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:14 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VUy27bMBD8FYKnFjCsOC87vuXVIkWSJrXTU4CAFFcyIWqp
-        Lim5TpB/71Kxa6c59GJAw33N7KxfpDVyKo/GE9g7KI7U8RGMJ8VImcnJKB8d
-        yIFEVQNHzCHEM6/I7DNmIOSMXWEEQuWETg+i8CQiqbyyWIqlp0pYFBFULU5d
-        QWCGj/iIn+YJqG0I1uNU3KgKhI0CVLBAfQmnqAQBqXZDNkAQ0QtqUcyuL2di
-        tN9XXYAwKiphyHaAQq9E3oboa66BACY8ys/D9aAXHCen2Do3kLnzAZhwoVyA
-        AXP/TqVC+6wiT8OMDmG8V2g9OTjMIR+PtFF7Wh2bnEs1FnEntSXH8YsYmzDN
-        skjgnB/mvs509vXnzf3zifmdRdZMbzQLC0/x4f9ZqRVBEeT0RTZAa6WuoYOU
-        6qnkgM5H1pg/jQ1KOx6Lqfm6ZtE4T9ZQa6DAoMXOxp7cezyAK755y5Qjtcwm
-        5yHPfZced5DT8q1LY0lFSD2UAzSKvrDEl/jWeSOI5sWX5FtMfmpaiqunpffm
-        icMruft8VasSdlQw+9WoiGU3brz+NR7yilpTkMc4RIiZTdEh26aH7J/iwwbL
-        jw1maVaz2fv2cW4dbDhu0TOy5SIihCTTh4nPvfP010IKz+Cu1c7mW60YYie9
-        +75jZybVtthVWsYaeB1IpzS4W76uftUlASQH3ib3ivtTHmCV3LFk7AEN+3rJ
-        1chZTIvwpLAXce6FBkHQWVj2NqBEel0FYSnYIXwZyULJWC01ib68gIYXyXZJ
-        PF2boFm0ebVK3uDfqfwBjm8y9XK2/wN4O4GqH6dxqj+GlMwqMXanLCWzvL7+
-        AblHupRSBAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:14 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925114650'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      X-Trello-Index-Last-Update:
-      - '269'
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '786'
-      Etag:
-      - W/"312-bf1f7f02"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:14 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=36f3fb872e42a6e869032faee98fbb93b58565eded6389134344a5eed7a9c53e; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:14 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"TestBoard","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/testboard","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
-        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:14 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578e03f5a65e78f1ad891c13/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925114901'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"11E6Ek3ZF1MTDuYY2Qln7A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '297'
-      Date:
-      - Tue, 19 Jul 2016 10:45:14 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=83dcc766f95e85f9f7b528c6525c3e418b681581b6bee4482523530b0fb29d90; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:14 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1wMbdsjbJkrDpWHbANFaoNlnG7VH33
-        eqjqDCHDOasFR5/wj3j9JnEkJyK18VQE6ZT02gTmRmPZwDrSkuRmv6+4zsua
-        v/zs01b2r8OUi993BjcV3+5DztmtDyaJfc+SCzkJTmlLymdfhjX2/yN+2scS
-        eUheljWmrTm74WPK7xhLx3gHsKjDcskxoQiCa2UABn0Ynp+wAAsAmJtD8CGm
-        uMWcmhyaS04eCdKQQuztX0m++ctEdUiMUQCMq2AEDmMoB2D6CoYjMQJyeYYK
-        hiExFnKLxgqGojCCckgz/j5GWhyGG0gzoYIxOIy2gGY4rWA0CtMZBmiGswpG
-        oTDKKEAznFcwEvUsUqvuNvP2Cxy3CV4vCAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:14 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e03f5a65e78f1ad891c15/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925115288'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"xkzdj+dtpdTwiVcevf7wVQ=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1467'
-      Date:
-      - Tue, 19 Jul 2016 10:45:15 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=8024333f83563cbcbba679befbbc6909ceb450da769aeda244daf5e96269170a; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:15 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+2Z/XObNhjH/xUdvdttOwsDEgL8m5tmW3rJ0tVJu63t9QTI
-        sWYMFIl4aS/72/cIG4e8dI43d/G1te9ihN6f5/t8HgVefbBkag0sPwiFQ8aM
-        M18E4djlaRi5aZBYPSuZiGR6oMVspLkWyhrkdZbB7axQArqOeaZEz0qh7pAr
-        PUy0PJf6Asb0HJdhJ8BudOI6A+oO/NAOmfc7jJkKlUCL5dUTrnk7rEwfF7zq
-        LMm/tqTEJZZpdCiV/ngbv2lzJGaxqNSLQpt1vnpj7o0mRQUdXeaY0lBrnkxm
-        Itd7xbmo2jXMeF7zrLl11WK1U5icxyIDQ7z6yPxeaMFkOZ8JWOKorGSuEaMD
-        FNiBjTByQ/iFFZYFjOERm1JCQp+5vkcZCXqWMms8lPkUer+MX441/WUfmsc8
-        PTPm/2CdF40fYAvnUsxlfrbY6XKjy2WqOlZJJePOrXFxFtdn7xeGX7l1MdJV
-        cc9cmV7mbjEze1804StbLMrGdZUstSzyKxnUYmHFy861sVkzagZeU60rlu5Z
-        FLPWpNf1eNuw91RIa3wtk+mF2W2RFeBfK85gUT2rVsaAzLl8szT3aZVB7UTr
-        Ug36fV2JLCts2H0/6XdccIdN6/Ud+6A2rBoZYEZxAF83xIF12fvn4Iu3Hnw+
-        24ng86P/K/h+LHg2QEdS8ynvIZ7CoFoqgY5gXJmL6gKBwwSHO9+geSW1QDJX
-        mmcZN6pGZ7VMBRoXFdr7oQ1YyuwwZEHgesShkRfQ6wF7QX57/u4kfv81YB8s
-        YDsu2Cxg2459UCg+A+ngWaMcvBIOnrXCwUvh4EY2uCsb3MgGg2xwMl4X5S7b
-        bpRHdkhoJ8pPJgJpwWdowhUy6pAaRId0YQplJkDyGppIIyTEYwg7KEuF5jBZ
-        lcFWbWSGSMCBCoHLiznilUAKDKeTCTJWUvbDocQL70QJDOhF6Thh1PFZGDo0
-        8TwRMc8Ye6uA+Qstvi/REJ2gffQcHaID9DNcLWtWeT6MIpsFzAlCyjzfCdh1
-        bhwND/4g7DTaOW64N7ihq/rzxEbHA5tho+3YBzXiOeZYY4ErnGGJcyzWpnln
-        62meOB0AnJYmVgEApSyFCegBancx4zK340JNcCLtZIx5WTZbaluqvqkcFArL
-        GT8Tr/PX+aNHaJgkotQ8T4AKhn2V5Kbme8MJIAOwg6O9g9V0qKrzHKTbYOZ4
-        hJqhUFzLLDV3IcsWdWVy7BTNpZ40zUano31AjJglYObl0FcDNn0BZqDPQvVQ
-        Hde5riG75ylS4PDX+QOebPxPebIZw/x3VxHno1Ue7eDqmUsG6FvyHRoJjeoS
-        7RV5AuZXHeua006hbrippVjgUBrYJGSU+pELaL0Osac/VfJP5zj/tBDz/vvh
-        ZxOItXYNunb1HM+z/jXexhvi7RmX1cILV3zjyXQFOEJvQuYufWwy4xNRijw1
-        +ryas6wrODCsJl03JwhvszlPYcLq6uDRmfnC0Ha+mtml9+F5R4yb8bztCMdA
-        H5cuwQQroXFd4qQNF9yGS3PKawGJV+GyhvlsvHXme3RbzG+5i3Mxx6k4x1Au
-        t8D+dtxPyf6GXscgXbBpMjVLe8BcQHc9F9D75IJbbmtzQegGjm8TAr8E5Off
-        +EeYPON7Wfwu+yJygf81F+x0LuiIcbNc0HaEXEAhF9C1uWBFz/vmgsDd/vmf
-        bfX8z+cKL0CLY67VBqngVh54PDxRt5gOlcrUjExCuCMFPCDC2a4j3L8Pwo3V
-        V9QOCKE2calDgiAIoxvvGyIi+dB9Mf0iqB1+pfZOU7sjxs2o3XYEajOgtr+W
-        2oZra5/UplsEtTdwHJtGu/E+xrv7fczyIWrqJZQwZxykoYg4o2m87Yeob80H
-        jdA+GqLH8PcJerv8tNSKvIgR2zxDdVwDsOvQmrw/JlH9q9r5Z6ef7zuXjgs2
-        C9W2Yx9UiBUWmOMY/qbW5Zu/AV4OFUacIAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:15 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7c/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925115551'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:15 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=cc972c347a6798d81d81ebadde3df181ab7ee0fdd26eae6972e973bbc5231c68; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:15 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:15 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d7b/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925115798'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:15 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=533b690c2da5a53a0719e81d6417aa89799d3f620abbbb5321a75354b0cd337f; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:15 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:15 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d16/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925116073'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:16 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=be0adc4e134912c1d8820fddd8ddc8d68bd6e58a722ce364f674858d6b8460c6; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:16 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:16 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925116362'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:16 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=6aea1f8dec3c221a107f2d856c82e82945936578b0636dd699e8f22fca00b88c; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:16 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:16 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925116673'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '675'
-      Etag:
-      - W/"2a3-854cbdcb"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:16 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=fe857ff2f9d318665715bbb76e398468c227569fe5da8b48a8f9d87fc10f3736; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:16 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"577b6e7368b58e244f1ebc06","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":65535,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"577b6f351f72355ef16a9074","name":"Sprint
-        Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":262143,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:16 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925116907'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '354'
-      Etag:
-      - W/"162-702e3496"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:16 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e469f169ce0cdd7038a2440b1c8ce54c7099cd5821dfed099ca14aa891623eda; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:16 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":14},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":34},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":4}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:16 GMT
-- request:
-    method: delete
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/idLabels/578e03f5a65e78f1ad891c24?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925117247'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '16'
-      Etag:
-      - W/"10-3393249b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:17 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"_value":null}
-
-'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:17 GMT
+      string: "[]"
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:37 GMT
 - request:
     method: put
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d70/idBoard?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb11/idBoard?key=mykey&token=mytoken
     body:
       encoding: UTF-8
       string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
@@ -9750,7 +885,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -9760,47 +895,48 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925117595'
+      - '1481203117872'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"+yp+cDCxyYu6wt5uBSUl1g=="
+      - W/"JSDih8nnIM2H58WPF1NGKA=="
       Vary:
       - Accept-Encoding
       Content-Encoding:
       - gzip
       Date:
-      - Tue, 19 Jul 2016 10:45:17 GMT
+      - Thu, 08 Dec 2016 13:18:37 GMT
       Content-Length:
-      - '676'
+      - '721'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA5VUy27bMBD8FYK5tIVl62FLjm6pU6ApUqSAkx6a5ECRK5sI
-        RQoi6bQN/O9dypZtFEgfF0NcLmdmd2f9QqWgJZ0Vc4izOmf5DIp5nTAxP09E
-        EdMRrZhYgaXlC90YFz7iEd1IeJZ69RmaCrqvGEaMmikLI2p9ZXknq5NQbVaV
-        X/1EGoTja+BPVw4aREpPj4vwFV4hPjdNA9rtyJhzjK+PZwGBoHXSaFq6ziOD
-        8EBL7ZXaniAuHev13j9iUBl7okjgzTWz7oI7uZHuB0pL4ySP4iJKzm+TuJzO
-        yqQYz6bpN7ojxIy71roOWENa2YKSGkqydq615WTSMKnHlbHriMsxryPWtmOs
-        YTJk2km4LI2NZMNW8KAf9NkZueAcWsc0B4IFOegkCzfvyO0aOiDSEkYWVwc6
-        0nmtsevErYHcLEkPRSovlQhRo4nxHalN90SepVv3acu75QdisRkclNpDHwH7
-        t5ZwbK2xI+Irr50fEaYFsd6izH3xl8yxXX9PWj2igGWr4SDFe8O6nZeKKocc
-        4lgkWZKxfC7wJ2Y0JPVTVtKGWd4PtitObZfGaUofQ+41q0ANeVwAT+ZTyIui
-        Flk+r6tZMUPIV67yPQQyHezN6ySeJrOsivOY87SoRC9p5+K9UaRYrk2Hb7I0
-        HC4O3luYDXRDsQ3Tnqk+dMw4uEsNul8Oy/Wa+n/qmmYN9px+YbLDQYcdMsqg
-        Flopxp/wjLNCuqTYjv7MmP8n4yW0oEUo7cjZ+q5VcCTNto9HhUlWkjfZW7IE
-        R3xLFkZz9KQ9sRzakxj7m3cRrTU29LzI5/gXEiZw16G16LBguHhKmX6n+OTT
-        x05+j2+CO/3fsyZZGrVJFmWRBRf5NuKDqmhQFaGqaFjO6KBq+wvTNQEDHQUA
+        H4sIAAAAAAAAA4VTy27bMBD8FYK5JIUVS7YlObq5TlEEddIgjx7a5MDHyiZC
+        kSpF2XWD/HuXku34EvQi8bEzO7ucfaVK0oKm08lFyjM+gZhfpFmW45/zJKED
+        yplcQkOLV7q2PiziAV0r2CizvIaKg/uBx8hRMt3AgDYtb4RT/OiotEveLv9i
+        GqQTKxAvVx4qZMqOt/OwCijkF7aqwPg+GfOeidX7XkJIUHtlDS28azGDbIEW
+        ptW6W85tVWvwsBPwdpTl3rOuhl/PeKhtc6RS4s2CNX4mvForv0W5ozjJomQU
+        xdOHZFwk02Kcn0+T7CftRWDEyQmZCQG1Z0YAQVkenGJP5sl8IgtsgvNbohri
+        WmOwX8Qa4ldADGzIijm5YQ5B1pRq2ToWCgq4S7sxXlUQgMJaJ5VBaZJslF91
+        8PntFfHAqj5YtKE1HTog2joUIsPd/Jg53HkHHRMLxBI6/M092Vj30pDSuo5d
+        Qq3tFqOabYMdI8zIgJW7RD31TGvCnFclEx7Lg9+tcggJHD0+hJJQXg2uUUhk
+        vN4StmZKM66hi3RQOytbETrznrlDqr5RZetb1+n8evcF2+Z7qWgPwEL7jlw/
+        PBJbkiSN49D3J4NvchOc2u92b3XJPDuyyMduGVCoUOQ+QMnPFl8qjEie8wwy
+        iGOZjJMxy6YSPzGjIagzr8Y6g7c+mKZRTJ9D7IJx0DsP4g5BHfsU4rEok3iS
+        pGMeZ7EQo5zLjr2fswPkfmUdYpKLUdjNDuMxt2twe+EVMy3T3dF7xKFGfaTB
+        sAqLp7d5QU7TM3IH/TuQ7zUYnBfxcnAyugj+oMMN02jAxu8tciqYXrfNcK3c
+        kp2h5Noi92iS5hnOaxPkPjpsKV15XzfFcIhG1Nqe4zsOxXDF08W3pd8grv1/
+        1BDLjuo8SiO3ExpZFNoEoZHuhUbWRHuhURAa9UKjXmfU6aRv/wA5ss0P/AQA
         AA==
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:17 GMT
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:37 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6f/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb14/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -9827,7 +963,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -9837,33 +973,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925117845'
+      - '1481203118154'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '354'
+      - '2'
       Etag:
-      - W/"162-3f7ce2a0"
+      - W/"2-d4cbb29"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:45:17 GMT
+      - Thu, 08 Dec 2016 13:18:38 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=45d40a817ce7e343a1bcd9c0082e71c04bb86fa0d238ab2720d903e8492a7e55; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:17 GMT; Secure
+      - dsc=febbd590acaee175b239193ad2642308f0967242ed2cb6a3faf81e77b9ecbebb; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:38 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":13},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":33},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":3}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:17 GMT
+      string: "[]"
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:38 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6f/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb14/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -9890,7 +1025,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -9900,94 +1035,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925118129'
+      - '1481203118473'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '354'
+      - '2'
       Etag:
-      - W/"162-3f7ce2a0"
+      - W/"2-d4cbb29"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:45:18 GMT
+      - Thu, 08 Dec 2016 13:18:38 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=3b9d86e73f653dd72700f82a650584479e5440f4e40b67dd043b7e13cc7449f0; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:18 GMT; Secure
+      - dsc=7e2976a7e82e5b7e4c6043b3a89e35a1458c25c2bde58d77cfab811198e34b98; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:38 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":13},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":33},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":3}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:18 GMT
-- request:
-    method: delete
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6f/idLabels/578e03f5a65e78f1ad891c24?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925118418'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '16'
-      Etag:
-      - W/"10-3393249b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:18 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"_value":null}
-
-'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:18 GMT
+      string: "[]"
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:38 GMT
 - request:
     method: put
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6f/idBoard?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb14/idBoard?key=mykey&token=mytoken
     body:
       encoding: UTF-8
       string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
@@ -10018,7 +1091,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10028,47 +1101,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925118732'
+      - '1481203118803'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
+      Content-Length:
+      - '980'
       Etag:
-      - W/"artfS34KEbYj7hhc/BAwgA=="
+      - W/"3d4-18278155"
       Vary:
       - Accept-Encoding
-      Content-Encoding:
-      - gzip
       Date:
-      - Tue, 19 Jul 2016 10:45:18 GMT
-      Content-Length:
-      - '681'
+      - Thu, 08 Dec 2016 13:18:38 GMT
       Connection:
       - keep-alive
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VUy27bMBD8FYK5tIUVS5b1iG6p00OAFA3gpIcmOVDkyiJC
-        k6xIOWgD/3uXtiUbKNLHxdAulzPD3Vm/UiloRbOihDhtcpZnUJRNwkR5kYi8
-        oRNaM7ECR6tXujE+fMQTupHwIvXqM6xr6L5iGjEaphxMqOtrxztZn6Qas6r7
-        1U+kQTjeAn++9rBGpNlpuAhf4Rbic7Neg/Z7MuY94+0xFhAIrJdG08p3PTKI
-        Hmile6W2J4hLz3Z6H54wqYw7USTw5IY5f8m93Ej/A6XN4iSP4iJKLu6SuJpn
-        VVKe52X6je4JseLeOt8BWxMrLSipoSKt99ZV0+maSX1eG9dGXJ7zJmLWnuMb
-        pkOlmzoUxEGpSMNLJGATYWwf9aM+OyOXnIP1THMg+DAPnWTh5AO5a6EDIh1h
-        ZHE90pKu1xq7T3wLZMAldS+VCFmjiek70pjumbxI3+7KlvfLT2PtAfoIuLvr
-        CMcWGzchfd1r308I04K43kHAIl8saOwofw7SDk25Yp7t+34yggkFbIcaAik+
-        GtbtPVbUOeQQxyJJk5TlpcCfmNFQtJu+ki7M+GGwY3Fqx1k8y+hTqL1hNaih
-        jgvgSTmHvCgakeZlU2dFhpBvHOUHCGQabc+bJJ4nWVrHecz5rKjFTtLe3QcD
-        SbFsTYd30jQEl6MnF2YD3fDYNdM9U7vUsWJ0nRp0v45L95b6f+qaZmvsOb1l
-        ssPBh90yyqAWWiucE8Y4O6RLyu3kz4z5fzJeAZpBhKcdOW3fWQVH0vn26agw
-        mVfkXfqeLMGT3pKF0Rw96k4sGCz2m5cRzRoEm18kGf5XuDCB+w6tRYfFw4VU
-        yux2jU/TW7ZQ9XcVRPy9apqmkU3mURo58FFvIz6oigZVEaqKxs0dVW1/AQwh
-        DlI1BQAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:18 GMT
+      encoding: UTF-8
+      string: '{"id":"58495b6b4e0b95667e0bbb14","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":3,"checkItemsChecked":0,"comments":0,"attachments":0,"description":true,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T13:18:38.744Z","desc":"##
+        Acceptance criteria\n\n* Arcus is configured to be able to work as compute
+        node with calvus as control/admin node\n","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":["58495b6b4e0b95667e0bbb2a"],"idLabels":[],"idList":"578e03cf104153b060cc27bd","idMembers":[],"idShort":193,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[],"name":"P8:
+        (1.5) Prepare arcus as compute node for Newton deployment (from calvus)","pos":262144,"shortUrl":"https://trello.com/c/oYslZ8dq","url":"https://trello.com/c/oYslZ8dq/193-p8-1-5-prepare-arcus-as-compute-node-for-newton-deployment-from-calvus"}'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:38 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d71/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb13/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -10095,7 +1153,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10105,33 +1163,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925118993'
+      - '1481203119050'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '354'
+      - '125'
       Etag:
-      - W/"162-ac417c9c"
+      - W/"7d-eb8e7a7b"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:45:19 GMT
+      - Thu, 08 Dec 2016 13:18:39 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=6f5f08fffe8f146c30521c675f0b4445eeacb3834f38cadc20da6094395f5330; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:18 GMT; Secure
+      - dsc=8e13b749b17b671c237d395abd441c59cd9fc294377e8bd6577a6b810dcde80b; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:39 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":12},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":32},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":2}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:19 GMT
+      string: '[{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":2}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:39 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d71/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb13/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -10158,7 +1215,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10168,94 +1225,32 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925119215'
+      - '1481203119281'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '354'
+      - '125'
       Etag:
-      - W/"162-ac417c9c"
+      - W/"7d-eb8e7a7b"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:45:19 GMT
+      - Thu, 08 Dec 2016 13:18:39 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=fb8a1000fc4fa37f03b606b69f8dc6f5d37c632befe18861da2838b33e44d1fc; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:19 GMT; Secure
+      - dsc=42e1c2ec6d55469be0c0c06bd03f45fe81de7ecf651aeeb2e1e1ba5870e85c3c; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:39 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":12},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":32},{"id":"578e03f5a65e78f1ad891c30","idBoard":"578e03f5a65e78f1ad891c13","name":"Dependent","color":"purple","uses":2}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:19 GMT
-- request:
-    method: delete
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d71/idLabels/578e03f5a65e78f1ad891c24?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925119513'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '16'
-      Etag:
-      - W/"10-3393249b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:19 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"_value":null}
-
-'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:19 GMT
+      string: '[{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":2}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:39 GMT
 - request:
     method: put
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d71/idBoard?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb13/idBoard?key=mykey&token=mytoken
     body:
       encoding: UTF-8
       string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
@@ -10286,7 +1281,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10296,46 +1291,50 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925119837'
+      - '1481203119659'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"ne+TRJcQNpufmiPGkgUQPw=="
+      - W/"kE0T0/5BpqQP0G60sQoNeQ=="
       Vary:
       - Accept-Encoding
       Content-Encoding:
       - gzip
       Date:
-      - Tue, 19 Jul 2016 10:45:19 GMT
+      - Thu, 08 Dec 2016 13:18:39 GMT
       Content-Length:
-      - '638'
+      - '820'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA5VUyW7bMBD9FYK5tIVli5a1WDcn6aFAChRwkkOTHChqZBOh
-        SEIkHbRB/r0j2bLdQ7pcBM7CeW+Gb/RKZU1LmuYFxEmT8SyFvGgYr4slq3NG
-        J7Ti9QYcLV/pzvj+EE/oTsKL1Juv0FbQ3aMbazRcOZhQFyonOlmduRqzqcLm
-        J8JgObEF8fzFQ4uV5ufmVX/qb2F9YdoWtN+Dce+52J7sGnoA66XRtPRdQIQ6
-        AC11UOrtrOLa84HvwxM6lXFnjGqM3HDnV8LLnfQ/kNo8ZlkU5xFb3rK4XKQl
-        W07zYvmd7gEx48463wFviZUWlNRQkq331pWzWculnlbGbSMhp6KJuLVT7GE2
-        ZrpZHyz5i4tCFbQPUcW9e9SP+uKCrIQA67kWQLAvD53kfeQTud1CB0Q6wo+Q
-        pAta4+TJ5erWHXJ+C7o+siZGE4+R9d36M3E4CwFKPepDL9fc8/24ziY3oYBd
-        qNGQ9aXh3V4aeZVBBnFcs4QlPCtq/MSc9knDoynp+qd5GFWUn6toHs8L+tTn
-        3vAK1JgnahCsWECW502dZEVTpXmKJd8JZYcSiHRUq2hYvGBpUsVZLMQ8r+qB
-        0l6Uh3eX9XprOryTLHpjdZTSldlBNzbbch24GlynjKNY1Mj79bgr77H/p6lp
-        3uLM6TcuO3zJfiWMMsiFVoqLZ7SD62XLlm+TPyNm/4l4DRZ03bd2wrShswpO
-        oOnb04khS0vyIflI1uBJsOTKaGFC584U15hukCIWsAbvZ2maZPgT6Id+16Ga
-        6LgiuDpKmWErxGyZSL5i90Ozf8+aJYvIsjRKIgc+CjYSI5FoJBIhkWGn6Nsv
-        LOXIk9IEAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:19 GMT
+        H4sIAAAAAAAAA41UTW/bOBD9KwR7aRdRLVmW/HFznWLbRZstmraHbXKgyJFN
+        hCK1FGlvNsh/3xnKTnzYogUEmx/zZt68meED14qveLWYLaumbmaQN8uqruf4
+        3zRFyS94I9QWBr564HsXaJFf8L2Gg7bbj9A14L/hMfpohRnggg+xGaTXzdlR
+        67ZN3P6LYdCd3IG8ex+gQ0/1+XZDK0Khf+m6DmwYg4kQhNw97xVQgD5oZ/kq
+        +IgRVAS+stGYtNy4rjcQ4Ejg8SzKdRAph++3eGjccMZS4c0HMYS1DHqvwz3S
+        neZFnRXTLF98KcpVsViVy9fVIv+LjyTQ4sULtpYS+iCsBIa0AngtbuyN/Y1d
+        wSE4y/TAfLQW5WK4CztgFg5sJ7w6CI8YZ1u9jV5QPgS7dAcbdAcElM55pS0y
+        U+ygwy7BN5/eswCiG41lJGUSmhCxpzwU3W3OPdNd8JA8CXKsIOGvrtnB+buB
+        tc4n7wp64+7RargfUDAmrCKsOgYaXa+NYcIH3QoZMD34O2qPEPIx4smUUXo9
+        +EGjIxvMPRN7oY1oDCRLD713KkpS5jlyQupRqDaG6BPP3z+/RdnCSBW7AzDR
+        UZGPX74y17KiynOS/cZiSa6oUWn9xjjqKRL+GFsbLC0BhJdxGKXo+hiwKihJ
+        ylawO4s1SLoQtzNe6KfXBuIw0Rbhxz64FEGctd+PO/GCQ4csTgZavXHYBjR+
+        83lTQw15roqyKEW9UPiTC05GaTAMikh9+4NJLSt+S7YfRAPm2U4JuZhBPZ+3
+        qqxFs1TVyQ7dpbgLyEvZFvmsqMomr3Mpp/NGpbjjdB+HRavrnfOIKZYz2q2f
+        hnLj9uBPKXXCRmHS0bPFU/bmxO7h7NX5P46/qI0VHUrLj1WeXEIPVlFAekGM
+        Q1a8jx4rgAdxoLmfPt4+wT4tV+zl9BW7TPVlfyIYnwd5dxpc/OAfnGcrDM7b
+        EE4T8VIKs8cWSB30Cl33jjzPF9V0ge8fyfTVY5H5LoR+WE0mOHfGuNfYaBM5
+        2f8Rmnfv1kui9HOrCcqd9ctsmo1dmDlkORDLzCaWGX4nlhmxzEaW2UgySyT5
+        43/TM1Lx5wUAAA==
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:39 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d1d/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb0f/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -10362,7 +1361,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10372,7 +1371,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925120087'
+      - '1481203119920'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
@@ -10380,24 +1379,24 @@ http_interactions:
       Content-Length:
       - '113'
       Etag:
-      - W/"71-f4b7b51d"
+      - W/"71-dcfd41be"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:45:20 GMT
+      - Thu, 08 Dec 2016 13:18:39 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=85f2adc351528a4a9df6f7b9ddf09de159e96e08ae91ecbd7e387be6c2a8c547; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:20 GMT; Secure
+      - dsc=aa5769e56e40bfff8fddefa442fc51d348712f09cb6d6dc44dde8028e448522b; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:39 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:20 GMT
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:39 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/578e03f5a65e78f1ad891c13/lists?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb1a/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -10424,7 +1423,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10434,200 +1433,33 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925120340'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"11E6Ek3ZF1MTDuYY2Qln7A=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '297'
-      Date:
-      - Tue, 19 Jul 2016 10:45:20 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=b3b22582c7ed75aa748521dfa2d4d90553d322716ba52f04ed6644f8a14ed849; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:20 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA6XVu27DIBSA4VexmD1wMbdsjbJkrDpWHbANFaoNlnG7VH33
-        eqjqDCHDOasFR5/wj3j9JnEkJyK18VQE6ZT02gTmRmPZwDrSkuRmv6+4zsua
-        v/zs01b2r8OUi993BjcV3+5DztmtDyaJfc+SCzkJTmlLymdfhjX2/yN+2scS
-        eUheljWmrTm74WPK7xhLx3gHsKjDcskxoQiCa2UABn0Ynp+wAAsAmJtD8CGm
-        uMWcmhyaS04eCdKQQuztX0m++ctEdUiMUQCMq2AEDmMoB2D6CoYjMQJyeYYK
-        hiExFnKLxgqGojCCckgz/j5GWhyGG0gzoYIxOIy2gGY4rWA0CtMZBmiGswpG
-        oTDKKEAznFcwEvUsUqvuNvP2Cxy3CV4vCAAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:20 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/578e03f5a65e78f1ad891c16/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925120590'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"MFo2Q4wHZ0MyHVsOP4gTDA=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1454'
-      Date:
-      - Tue, 19 Jul 2016 10:45:20 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=0b6521e07b12bd1f01bd913fc939e5c4e1969d1b7db4469ef30eb819272e3f16; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:20 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+1Xa3PTOBT9KxrzBTpRYjux8/hWCgy7U1iYtPuAMkW2r2NR
-        WzKSnGxg+t/3yo88ui2QHViYnWU6g6zHfZx77pHy+qPDE2fmBOMJuMM0YGEA
-        40nqsWQy9eLh0Ok5cQbx1U8GirlhBrQzE1We43QuNeDRlOUaek6Ca6dMm+PY
-        8CU3a7Tpu15I3TH1pmeeOxt5s2Dcn3jTV2gzAR3jjnb0iBnWmeXJQ8nU3SF5
-        NiSenHJt7t4T1nueQRGB0r9KY+N8/cbOzTOp8KBvx8fGsDgrQJgTuQTVRVAw
-        UbG8ntru2OSJrlkEOcLw+g7v/sRBV4IVgAE+Yjxfk3msqoIwQzyPFT2ScJZT
-        Lmbk0eMZccMp9fEf9d1gOu2Rk1czMvJdihMBnU5ogBiGPfKCaR3LBHBx6OEf
-        ZlhKjMJ3RxO352ib1ykXV+jzj8fPxfFTwXFLxJKFLdlHZynr2uHWJYcVF4sG
-        nRacNjldRTpWPNqZSuUiqhYfmmJtqNBY2n6e2JE9ZWdlYRFrtrANgs23Lbfi
-        peFSbKlTQYP99c7YIl1bzbHSuitfW9LmM+8K8UkOYzm+kFVtyeaGx1drm63M
-        JbLCiXIMqudU2gIYutdvWrjPVY6rmTGlng0GRkGeyz5mP4gHOyW4BdPq8wcH
-        Pk0sdai21KHMUEsd2jKHJkD3eUPjD/RvrKFlSxracua69+l2975+u/s/Qrt7
-        /1a7nwErZoQlVZoiij0SZ+gDFA40DrH1U/s/NHMFK6RiOWgcYhRC9oheyjxn
-        JusRkyEsaGPT50Ho3ujzd8WT5e/ypfd/n3+3Pt8pwWF93h0ceNQgZ2hHGdoy
-        hjaEoVu+0A1daMMW2pGFbrjymf4efc3r3J+5fj/c6++zDJDU2oAikWIizohM
-        kch2Ms64ALUmCpDN3EgcxkyQCAgXxKwk0XU0swtxIY7I0dGFI0sQF87RUY+s
-        MhCdXa6JXSCpVETAilh1QxdKVouMFKAWyHhSYkbo6X0FSCnSmEuV/HCHwQjq
-        QxgaU5DUphkez4FpIEwkREgiMQ2F7cwE9hnBfYRhMVe4HcHHDDJED+1KTNwa
-        a43XoCpi5MYgi3JociX3eR/61gxBxim65JrbxV0fiAi2LYnWpFEp8vK4Dsge
-        uhJyJbowKTIP6Yw7sImbsyn/E5IHfQvouYa6DG+fsSsgtdS9JTmKCKaOSdj4
-        NJh6Sx1afejevXsEBREZXdku1nauo7JtfZzqr/gVLwAvpb5Ui4H9GjzhOcx+
-        iuFSSZZccnGJVi+fYxdlK0zm8gyUsuXnoC8p678rF9/vUghvvRWcIPQnzJ0k
-        vpekcRx4gcvS8SiInDvvCqOqw6+Kuv1sgzRc6XTec91w6O8L/WkCwyp6f/zD
-        Cf3whtA3QPwHdX6nAofpfHdwgNpZ9xaVKW0rflOtw70ckhC+7mtsgq+x8Y5a
-        2/6OYygNKjXKDrYlKM4aAbZKbnV2fj5/TE6BlSgMUMSYWC2YFc+NFe5YCsOs
-        sKPkaNJQAYGxSx0aC26yKmrQyGWVpLISiVoPIqkzCxUMGjTqCdp56WJIZFxZ
-        rjHLL/sD6hazNsZ927UQnSiwcDNBu0SoTWTjgqLO04e/zJ/ajKrSQphYJVSQ
-        5hCbOsnEavlenm1gqK/t9cWILiHGZ/l2U32DbNCr7eATL5digXe9KshCshpG
-        dMaFgYWyQrDChGoFbrS1OYbrqUJ4VBWbStVqUZX4iS+GC/H9hDMYfsv3dIr+
-        71ga7ejnC8+fkfvhA/KwRmrLz91ydao6HobD4IaqvvqtPB/9/Hz4bVU1uFVV
-        /UOez4eoaofceBc51ILY+cd6mx6oty8Yt2+gPcFl9Q+ZRnGH3meeqVjmwzye
-        iwS7boVtpPBVAzue11aKVxvXnvclYr9DjMPEvjs4wA6hpefTkNZtvNUc/Om+
-        Q87rN38BTLQ2738TAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:20 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c33/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925120878'
+      - '1481203120223'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '113'
+      - '248'
       Etag:
-      - W/"71-f4b7b51d"
+      - W/"f8-932b23b9"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:45:20 GMT
+      - Thu, 08 Dec 2016 13:18:40 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=42cd96e2bebddfb56451291a71dae264093c4735f1dff8e7b24ccb6194477a7a; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:20 GMT; Secure
+      - dsc=df7575f8a2b0d0bc4a0e85da227c65e719bef00d1b54abc093205d9fe4b06a44; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:40 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:20 GMT
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":19},{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":1}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:40 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c31/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb1a/labels?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -10654,7 +1486,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10664,220 +1496,33 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925121155'
+      - '1481203120498'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '113'
+      - '248'
       Etag:
-      - W/"71-f4b7b51d"
+      - W/"f8-932b23b9"
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:45:21 GMT
+      - Thu, 08 Dec 2016 13:18:40 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=65beabfac333d2dd7cc1e6edb2d20c4d088b5355e17cd8cbb1f8b2216b14edbe; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:21 GMT; Secure
+      - dsc=5ea9e292d27918dbc86f2807be01ffae82cc8d3a4ec59a3dc032b538b52727af; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:40 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:21 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f5a65e78f1ad891c43/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925121397'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-f4b7b51d"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:21 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=ed5b444a3c39d3b72669947efe571923d9356e5711c6b0db35c058ba6c15ee24; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:21 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c28","idBoard":"578e03f5a65e78f1ad891c13","name":"Sticky","color":"blue","uses":60}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:21 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6e/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925121672'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-f3beaa98"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:21 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=81cbd62d97aca798b0b927690fb726dd42c931fe8ab4910d5d1305d5796e4480; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:21 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":11},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":31}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:21 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6e/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.707.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1468925121889'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '238'
-      Etag:
-      - W/"ee-f3beaa98"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Tue, 19 Jul 2016 10:45:21 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=c2af1aaf92381eeaf82d84d4305cd968bb6acf59cf7ca96e4388cfd14a73615e; Path=/;
-        Expires=Fri, 22 Jul 2016 10:45:21 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578e03f5a65e78f1ad891c24","idBoard":"578e03f5a65e78f1ad891c13","name":"Under
-        waterline","color":"yellow","uses":11},{"id":"578e03f5a65e78f1ad891c2f","idBoard":"578e03f5a65e78f1ad891c13","name":"Pairing","color":"black","uses":31}]'
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:21 GMT
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":19},{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":1}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:40 GMT
 - request:
     method: delete
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6e/idLabels/578e03f5a65e78f1ad891c24?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb1a/idLabels/578ddfc161a876504837d07d?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -10904,7 +1549,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10914,7 +1559,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925122149'
+      - '1481203120839'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
@@ -10926,7 +1571,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 19 Jul 2016 10:45:22 GMT
+      - Thu, 08 Dec 2016 13:18:40 GMT
       Connection:
       - keep-alive
     body:
@@ -10934,11 +1579,11 @@ http_interactions:
       string: '{"_value":null}
 
 '
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:22 GMT
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:40 GMT
 - request:
     method: put
-    uri: https://api.trello.com/1/cards/578e03f6a65e78f1ad891d6e/idBoard?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb1a/idBoard?key=mykey&token=mytoken
     body:
       encoding: UTF-8
       string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
@@ -10969,7 +1614,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.707.0
+      - 1.823.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -10979,43 +1624,3137 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1468925122565'
+      - '1481203121313'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"zHxu3/NYZ1bBRmmS3YHpCw=="
+      - W/"pMfKYeTI5Szu5eQPSl2pGw=="
       Vary:
       - Accept-Encoding
       Content-Encoding:
       - gzip
       Date:
-      - Tue, 19 Jul 2016 10:45:22 GMT
+      - Thu, 08 Dec 2016 13:18:41 GMT
       Content-Length:
-      - '741'
+      - '788'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA41U227bMAz9FUF72YZ4tpPYTvPWdgO2obsAaTegax9oiU6E
-        ypIhyS26ov8+yqmTDOiwvhgSzcs55KEeuJJ8yYtqgdmsKaEssFo0OcjFUS5L
-        5BNeg1yj58sHfmtDPGQTfqvwTpn1F2xrdD/ITDka0B4n3Pe1F07VB6bGrut+
-        /ZvKUDqxQXHzKWBLmYrD62k8xagpWW3bognbYhACiM3+LjEW6IKyhi+D66mC
-        7JEvTa/140HGVYAB768H4ng6Wvdkq0Oy0yyXhM7HGHIhAJ1GOj5OXhjdPBt9
-        TXi09QfNkORyBj4ci6BuVbgnd4ouk6xK8qPzPFvOi+V0+m6+qC75lit5vHrF
-        joXALoARyIh9QKfgylyZt+x8g8x2aFYXqw/sDKFjnoAK1Jopz+pe6cCUYcKa
-        AMqg8ww82/aQhhR/bULo/DJN1yps+vodoU8JdC8b2xvp7tPa+k0aHGLaEnB0
-        gyEZq4wYpBV9HBLEwTAIz6WNGP/OfaduVHrqkLqSgElGIkkksiuRNNYlJ99W
-        HyOjvostlCxY5rDRKMJAUpIe/+b5BMxRw8CwGhkw36FQoPdOjDLvuzfk8ROm
-        rVknRLRlawtDG6mYMgHXjkqzOyLEAlGOMiWuQxj9bxy1x/Ui9FTTNoSUrgjt
-        lXma5HsIsNXpgWQnHFtQerwoeWLBbXeyqkssMctkPstnUC4kfTLgk1GRWvm4
-        E7/+pUnBr6PvGdSoRz8hUeSLOZZV1chZuWjqoiqe/CjdTuCiybN5XszqrMyE
-        mFa1HOpuVz4mG0JWG+soZlbEy/FuUU/tLbqRUQumBz2Y9h67fdAjuIfdS/Q8
-        xBe2xkAbV/A7KEeKiA+O1Zaw8FqDuKF77+OjMM3ibo7O+XTJXpdv2Mkwyf3+
-        HMqJQjtLkYucWku7HplfOJobH4VOw9babvcnvfzZXcw/f53Fiv/3SmdF0uXT
-        pEwGMe2Vr0xyAOHxDxFR0oevBQAA
-    http_version: 
-  recorded_at: Tue, 19 Jul 2016 10:45:22 GMT
+        H4sIAAAAAAAAA41UW2/TMBT+K5Z5AdS0SdOkbSSExoYAaSDECg/AHnw5bQ2O
+        HXzZGNP+O8dpuhVtCF4Sx/nOd75zvaZK0oZWi9my4jWfQc6XVV3P8c15weiI
+        ciY34GlzTS9sSId8RC8UXCqzeQstB/cJr5FjzbSHEfWRe+EUP7ha2w2Pm1/o
+        BunEFsT3NwFaZFocfh6nU7JCfmHbFkxASDmiLAQmtsM3/pSQHHRBWUOb4CJ6
+        kBFoY6LW/fHYtp2GAIOAmwMvZ4H1MXw5x0tt/YFKiX9OmQ9HIqgLFa5Q7jQv
+        6qyYZvliVZRNsWhmxXha1J/pTgQiHj0iR0JAF5gRQFBWAKfYV/PVPCWrLRAP
+        7gIcWVtHhDXCRudh7CM+JBDliYvGYCKJNSQgHMxGGUAKvEJ5UQ48rgezQDSg
+        QkQDubTu+8C8J/G2BcKZV4J0qgONVD65NSCwQiTYBzT8j4AP0ZDjvSW5VGFL
+        mCGvV6v3pHP25xV57AGD39WsVyQhMKX9k2Sd8uP9w95Vry84qzUK5Fe9Bs8w
+        jFcqvI6cbJyNHWGeoIFMIntRe/tEfyfsfjrPPp69JB7LLkDrVBQs17vUxOm8
+        UthuO7kJi5F8wzxhZDI5c74h2xA630wmyqwdG5s46MZAJzvjyYnynWZX421o
+        9XMln1XLajpL5C+0Tc1MoglK/8GfQnaAvSbHQxudsMAOuvfvjTyi0GJa9wAl
+        X1jm+umdz3kNNeS5LMqiZPVC4iNP06tkP1da+TQ9X/4y6FVJzxP2lHHQdzjJ
+        xGIG9Xy+lmXN+FJW1YBDut7vAvJSrIt8VlQlz+tciOmcy97vbjkMs6bk2dY6
+        tCmWVfo6up3pY4sDsg+pZSYy3V/dIW6j13t11wdL6yGN/5kbg42GiKFWkxPo
+        wMjkMC0gbVEV7aLDCuAFFj5to5vzW7P3Rd6Qx+WTfjzutza24L1hQp7OIs10
+        OVsWU9yVKScfHVaU7nstOGxV2/eYmPyY+u5l3e+b+G/UBHObdUWelRnOQXYr
+        KUuSMgmZNdmBpGwn6eY3EY9KVgIGAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:41 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203121604'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '124'
+      Etag:
+      - W/"7c-1a0c1e2b"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:18:41 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=50ebf6332bf001205962ae8f9af36e4284d4370a7d8c3aff68fdc3840bd9f919; Path=/;
+        Expires=Sun, 11 Dec 2016 13:18:41 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":18}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:18:41 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/NzGCbEeN?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203177578'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      X-Trello-Index-Last-Update:
+      - '82'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"SFWQj1E2s/62p4FKw4aqWw=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '590'
+      Date:
+      - Thu, 08 Dec 2016 13:19:37 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=fc46891c8dfc9e69125549fd0d441ae5fbf4e4645ca6282dfcc7cbb4cf6219fc; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:37 GMT; Secure
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4VTwW7bMAz9FUK7bEDaJNuapL41aTZk6LJsSW+9yBbjCJEp
+        g5IdtEX/fZSTou162MWAH8lH8j3qUVmjMnUxnhizLYajoZ6MRxeDr5MvYzMY
+        FaqnSFcoGRsMEdY1W4ow9ZqNhAyGQkILisikHeQJh61niKyLvaUSDp73YAki
+        6gqu3JbRnN/RHX3cJKCyIVhPGfzUewQbAXWwyB2F01wiYOKWrgEDRA/cEKxv
+        5msYfu5YdwhGRw2GbYsE+T0UTYi+Eg5CNOFOfTo/DXoteSqjxrmeKpwPKHtv
+        tQvYEwl+canJPugo0zwn1ZboVVLDTnbdxViHrN+PjM7588JX/by/fPg+y+e4
+        7EcR6Sx0Ip3lJ5HCznO8/X+xpNaM26CyR1Ujn6S5wRZTqXC2OqIktT6KsAIZ
+        G3TuMPUQpkqUklpVYZUjBwEttTZ2G73FA7rtD29lz8iNLFbInDPfpuAr5Ko8
+        dqktH/sW2iEZzd9E1zkdOz9rk4vbJfuG0i3VDdcuVbygi0qX+KzrP/A6EZv3
+        wY0VkvcNpmzLXSQMaSkZZ/+m0cw7zxL4MLkcDS7n3dg0xVWTO1u8rCeQOP7m
+        f3US+AVbJP1OwFNPOZ2jW8pj6BwqGVEUVMt0ZfD7SjrdJ1MPgt2Skfs7CBs7
+        S0kJz5rK7hV5yBEYW4uHzjlOq59YCA8gpsoFJ+fTPRyVzNQ11qK9OJyWdU2C
+        1tEW+/tkp3wz9QedvJ3Uy9nuvarugPfdOLXT3SmnYpFKsJW2nPx9evoLDMma
+        awEEAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:37 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203177860'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '546'
+      Etag:
+      - W/"222-273e1966"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:37 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=c32e6df82b732af57094ef524055061ee19d01768c3e4b6f44e27a89995fc804; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:37 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
+        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
+        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:37 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203178208'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      X-Trello-Index-Last-Update:
+      - '20'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '805'
+      Etag:
+      - W/"325-d20b3c91"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:38 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=923a24de450e0317cf09f35d5c69abedd7ffba2f23d4a05f9846b4c3fb66b0c2; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:38 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"Test Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/test-planning-board","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"sky","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#00AECC","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
+        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:38 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/lists/58495b6b4e0b95667e0bbb0d/cards?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203178479'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"lyihBA8kZ4eD2Dl2QPL9CA=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1616'
+      Date:
+      - Thu, 08 Dec 2016 13:19:38 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=96454c3d332fba87d3bfcf9a5cc189418edcf8da6ca5f0d14842f6a07eadc594; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:38 GMT; Secure
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2YjW/aRhTA/5UnV9OSNQf+tkGqJkKaLFLWdiFZ2qVRdbYP
+        uMX4PN85lFbZ3753BgfoQhMm2qRaQQL7fO/53fv4+Z3PPxo8MdqGF7otL/Ij
+        l5lRy/P9AP+jyAqMHSMesvjyULFRT1HFpNHOyjTF4VRIhqJ9mkq2YyR47YhK
+        1YkVv+Jqgjpt0/KJZRMzPLGcttlqW1aj5bh/oM6EyRhndK4oT2nEUxRoQ/g0
+        fBrgN4Rn4ISwRcAx4QfIBJesDba/PRPco4rWVvBkV9CiWkEQJkk/tnyLhoHv
+        mW7oBInpx4aedMSlWrlKM6nm/MpGESvk70LpZZ1f6LHeUBQoaPuhPusoRePh
+        iGWqK65YUdswollJ02poPuPGMXhzGrEU/Xa+wsbQNvBmGR0xNLGXFzxTEHht
+        CBqW3QACVksfoI25QC2W6bXMAK+5oe0GbmihaVKbecSzS1TQ/eC/eH2WOjg/
+        oslAB+yjcSWqyJk7xhVnY54NpoudrXVmqSwjGRc8Whjqi0FUDj6g2sVEmGqa
+        n3b1kZbSo2Kklz+dQm/cMT3X0St4rrjIjLYqSp03Jav9iIddMcpTptjMgOvb
+        BpdkeFLdPMX4yjpos0BOT9Pa+XWirwrBPXOpDpPi8eVEO0WkAjPBiFI0asco
+        pfZz6FxfzKJyWqR4dahULtvNpipYmooGOqkZNxcidYvry7sFm5iXRFYJQwKP
+        BLrYrBb+Gtc7n6/rcPN1HSzU9QMWautrFeqBoGkb9vl7eJmzDH0YXwLPpKJp
+        SqsEr+vVC0Pf8hqBbTuBZdt2sFyvPbXbi0Rn/9HX67+L7/9WsAuhWq9ga0Es
+        2BYZYOKQPn9PBOaN1HlDlvLmjto1+5uu3dD3F2r3ZMhAMTqCIZWgs4MrTDpQ
+        Qp9UYQWFU7hOJKARFhOecwljvFmR8ow1QKuIMTASMJRiDLRgINEhKh6CXr1s
+        PCAgzFsBUSuMlxX6Gs4bxcbfMP2eQQdO4DkcwxEcwgs8ml2puWHbvudbZsNu
+        +W7LbfmOv8yN4+HB6clZePDouGF9f84vV/9CpNbDRi2I2DDJmFCiCCMFSQkn
+        GWF3PuRbmwWFjV3oYvP+5Al04pjlimYx1nuBRCg4fZu9zX6qCNA77T3Hsmej
+        GJcESIiI4j1BZHDEaA6u3bDrqTezxqK4RJRwNYTdl71fPne9K7JYlIVk+o5o
+        ywud+vr43DEbSLULLKuCZvhMRnTpfylLNhWVE60wgfGQI5FG9JJJPUNI4CM6
+        0PiTCvq4NWnAbjmAguUYYL2CPk9xBVRBHS5dNBzB3ZCYEFXUMBnG73C4EQ/4
+        zzx5ZpmWHVb91gMBL7gdeJvpiIJkAW2vLKsNW942HDMd6nnUMORpHfI53lqo
+        IVyJtyN776/fVPf1l8WbfzfenAfYxqyIthsb/xV8QbIm+E6zhBXzh/oCASea
+        UOMbBlrhfRi4EM71GFgLNjGRSW5ZxCNFlV6kTi8iMqLTi7g2uXvn429852O3
+        7gnFbirKBPZFmSXFROOkKLMMk1jXx3wPUUo9pFss3R9WENV1c1NN0/ZKt1Fa
+        BbKtopUaUlUJJSxPxUTnKnJLlqlCqGVAK3JqxVWribY14FD9KCETCjIWMylp
+        wdMJjBhFSdQaMW0e5KxARqC2dNLQa9ibq09EXOqDqmuFrfP5EpavoJVDVrCL
+        rTq+A2RwGVXx1ctrxtov/albmmN+yZuVp8jMU+RwoTsmByVPmA5572WX+Nvb
+        Wn2Z61jNelREGSCD9cnUF5/4fdHZb7MHbESDr8dle8rlvZk/9peccENkx3ID
+        315J5PzPydluMrS+LJHdx/liaRWR3W+WyAvhXI/ItSB2pQES2UYiTwuNxH1d
+        mDfb2jtZ7G2exfdtUD/H4s5Z75FT+JhJbH1xUaXU/erMZjQk4TIupW6zq0ZX
+        m5KXUcpjqCBbbex3tEmVuKx25v2C4fwyx3YYMY12sIQlD0pG/+uR0UEyup+Q
+        EX05Z6JjWa6/komhKIUquuPvTJxH2Pl2u9SFcK7HxFoQmegjEx3iLjORjuWd
+        NDQ3TkMzfBzv5K21Xrl5m37l9k5/oAfPoQO7+LsH72afeZm7geesftfmHJ2+
+        euPtvXn079q+v6NfCNV6JVwLYglbRBJGKInwNzGuL/4BOmx8wSUfAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:38 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb17/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203178751'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-dcfd41be"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:38 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=cb260590e21ed8f0986da7459e24b7618e0ced3e07e6c64fd3c0d4dc281a9958; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:38 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:38 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb18/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203178996'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-dcfd41be"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:39 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=2b7b5d5455629071e7cad1617007db44fb2de711f0dc64df0c20dbd28b98fc69; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:38 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb0f/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203179236'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-dcfd41be"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:39 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=52169544e221fb3785455d616ca85b2df6c0873f1dcd87091eaa7ef426df03ee; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203179461'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '124'
+      Etag:
+      - W/"7c-1a0c1e2b"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:39 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=4e7784f77103a95e36cd106854ea06967a9da9c5c43492feb572d8f2e8b67c56; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":18}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203179726'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '674'
+      Etag:
+      - W/"2a2-402ce24c"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:39 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=7e8ede16d7cdd2aa53de11d50840efd3e77e09efba5c8f13f29affbb28a14bcd; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"57ab15db6568cc9735820ee3","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84863,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203179981'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '124'
+      Etag:
+      - W/"7c-1a0c1e2b"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:40 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=55fdd0015483167d3d25a7c549978d9e45ed07e92122feb2c9a9c357fa9ae2c2; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":18}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:40 GMT
+- request:
+    method: delete
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/idLabels/578ddfc161a876504837d07d?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203180298'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '16'
+      Etag:
+      - W/"10-3393249b"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:40 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"_value":null}
+
+'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:40 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203180716'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"090EYxK1aBudb+yJ7TiKzw=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 13:19:40 GMT
+      Content-Length:
+      - '629'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4VT227bMAz9FUF92YbYsWzHSQwMQ5sOWIHsmnYY1haDJDO2
+        UNnyLDlBV/TfR7lJmpduLxZJHZKH4vEDVQXN6WSWziciEylEYj7JsimeQrA5
+        HVHBixIszR/oxjhvRCO6UbBVTfkRagHddwxjjTXXFkbU9sLKTomj0NqUoi//
+        YBssJyuQdxcOaqyUHbsLb/ksrC9NXUPjEJKMKHeOy2rn42UBvkHrlGlo7roe
+        OxQ90LzptR7MhalbDQ52BB6PuqwcH2a4vsWgNvaIZYE3S27dqXRqo9w90o0j
+        lgUsDqLZJUtyNs/TKMxY9pM+kUDEyQk5lRJaxxsJBGk56BS/aW6aN+SyArK6
+        Wr0nFhtL0JooSwTHnsQ0ZAm8JWkcxnvoAbU13Z0lW+UqcvZ59eFf9wvTSNN3
+        FnxH5PLJb8jb10kUMhbekgvS8YaoxhniT2t7eEq1975gQbaVkhWp+R1YjzCW
+        qJqXQLCQI2uudEjO+pJ00JrO+QnWSuME3JHKudbm47HfrdKah7a3EOLqxrYy
+        218YDmWp3qniLYtYPGOz3bOdc8ePtvXy4kYUaiSwB6jizPBuUOt0KjLIIIoK
+        lrCEZ7MCPxGnHjToSCvr1XL9grBTSW89dskF6J0c0MOkofoMokSuWZSySSKi
+        LJIynopiqP4k+UPKqsJXoSiNzHunB6UuzAa6PfGaNz3XQ+gZcZhRH3FoeI3D
+        0y+M5eTV5DX5Bl4vz6tH3ei9bpBOa/wfwljs21tP5arD56L7zbgOk8ywEjle
+        xue/v7rFD8zr/48a40hBy1gwCbqBRLAnEZgm8CSCNA5i+vgX+TQkCkEEAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:40 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb16/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203180977'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '124'
+      Etag:
+      - W/"7c-11505916"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:41 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=56a49d73ef6c3e26ed4aa21dc72fca728079389632f07b1d51a200072eb674e5; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:40 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":17}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:41 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb16/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203181230'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '124'
+      Etag:
+      - W/"7c-11505916"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:41 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=805096c6e924ccc5c8847d136e1c18f90ad30f847de1ffacddcf0f75a5b28c09; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:41 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":17}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:41 GMT
+- request:
+    method: delete
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb16/idLabels/578ddfc161a876504837d07d?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203181515'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '16'
+      Etag:
+      - W/"10-3393249b"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:41 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"_value":null}
+
+'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:41 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb16/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203181824'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"MdmvAjgsaracE5uxVrGUBw=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 13:19:41 GMT
+      Content-Length:
+      - '683'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4VT30/bMBD+VyzzMJiaJmnTtM0blDEhMTGpsEkDHvzj2nh1
+        7Ch2WnWI/33ntNAyCe0lsc9333333d0zVZIWdDTJpiOe8wwSPh3l+Rj/nKc5
+        7VHO5BIcLZ7p2vpwSHp0rWCjzPIbVByaH2hGjAXTDnrUtdyJRvEj08Iuebv8
+        g2kQTpQgVtceKkTKjq+zcApRiC9sVYHxu2TMeybKw11CSFB7ZQ0tfNNiBtkC
+        LUyrdXec2arW4GFP4OUoy9yzroaHJzRq645YSny5Yc6fC6/Wym+R7iBJ8ygd
+        RMnkLh0W6bTI0v44n/yiOxLocXJCzoWA2jMjgCAtD41ij+bRfCYzbVtJrmxr
+        ZLMlypGmNQZVI9aQ2xoMchEr0rpg8iUQG2z38y8kG/QHxCFbAVr3yR2+LS3T
+        AcJbgvw9+jPfBUmotd0GcUgDrtXeEWUIIxvbrAKwMq7j1ifX/pMjxnpiQIBz
+        rFF6SypgGImoHAI9UkNTMYNoetsPNVwe4KUVbTiwIDw5fTiU8P4FWZbQwNNp
+        6X3tijheKl+2vI89jUN5sQi6LHayxBu1UnGnVLRXKroOlLXu0KKvrZIQ4WF+
+        O4vys7MA39ahVzLQFnYNDSntJlx2Wvyj+7HYj2bfuUvm2dHAfDw7PQoVU/rV
+        QckLy5puYcZjnkMOSSLTYTpk+UTiJ2E0OHWjrJULA/vwwW5lGX0KvjeMg95P
+        JN4wqEOfQDIUizTJ0tGQJ3kixGDMZYe+27q3kHlpG4xJp+NwO39bllmQ5pU4
+        NrVlujMdPN5q1EccDKuwePo9HRTkdHS2nwAyu3qnJBKpLUYMB7gPuJMukLhv
+        UCj62nbf4PTaru0irn9vf17IMsW49v9eMRYT1bh4o2jX00gswgyEDXFd+pe/
+        htL+/LgEAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:41 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb15/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203182058'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '124'
+      Etag:
+      - W/"7c-10923321"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:42 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=d4f0266d9cf3c4afbde08b23126e088f94caa8d3dc85b7c45608e03e4d452846; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:42 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":16}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:42 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb15/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203182308'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '124'
+      Etag:
+      - W/"7c-10923321"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:42 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=3724b99e01b53dd289eb411af4a5b39c7e233152b5399e8e2086495add8513ac; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:42 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":16}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:42 GMT
+- request:
+    method: delete
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb15/idLabels/578ddfc161a876504837d07d?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203182618'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '16'
+      Etag:
+      - W/"10-3393249b"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:42 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"_value":null}
+
+'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:42 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb15/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203182952'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"IypsQxfll7SFf0IZVQ0lVA=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 13:19:43 GMT
+      Content-Length:
+      - '640'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4VTy27bMBD8lQV76AOWLVmyLPvmOg0QIAWKOmmBJjlQ1Nom
+        QpECHzbcIP/epewkvgS9SFxyZ3Z2OXxismFzNqmK2aQu6wLTejYpyyn96zqb
+        sAGrebNBx+ZPbGd8XKQDtpO4l3rzHdsa7S/aJo41Vw4HzIXaCSvrs6212dRh
+        85fKEJ3Yoni88tgSU3EeLuMqoohfmLZF7Y/FuPdcbN/iBmOBzkuj2dzbQBWa
+        gGyug1L9cmnaTqHHk4Dnsyorz/se7h5oUxl3prKhk2vu/EJ4uZP+QHLHaVYm
+        2ThJq5ssn2ezeTEeVlX2hx1FUMaHD7AQAjvPtUAgWR6t5Pf6Xn+BpTKhgUsT
+        dGMPIB3YoDVNDYyGxe8VBBcDv0UwHerV7eobEP8YHOkUqNQQbuhsY7iKYG+A
+        lHvK574HNdgpc4hjAYsuKO9AauCwN/YxEkvtelVDuPIfHWjjQaNA57iV6gAt
+        ckISa41RGHRoW66JTR2GUf1PdCZYaio4vsEXzSSkkU4ER5ODvfTbXkoXaiUF
+        iL5hj7wdREk93AG3CGuLlB862G+RQk0RNvf6NMcL7vnZ9b1/kwOGLZfqJUE2
+        Xw23vX2n07rEEtO0yfIs52XV0CflLCb1xlLSRfvcveP0XLCHmHvNa1Qnf1BE
+        oJ69wjQX6ywtsklep2UqxHhaNz378Q28QlZbYwmTzaoYLV6tuzQ7tC/CadCB
+        q37rLeO1R3WmQfOWmmc/yH7wqfgMF/2lw/LydCEkoTOUmxdFWtJzcrH8raUR
+        sa33nZuPRt6Sl8yQntRIjCoTjLfLPeHC/7NG1EbSZXlSJEe3JWKdGJ3wvWPP
+        /wAxt8bIOgQAAA==
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:43 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb10/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203183199'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-dcfd41be"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:43 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=a14e76239b7e0ccfb2960939b44ddc90054ea2ec596539605ea0c50e585c77ec; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:43 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:43 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203183462'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '546'
+      Etag:
+      - W/"222-273e1966"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:43 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=3a2027de5f1ed6905b407a55702e66071f1f93ec52ab6da0d2219dc56fc19027; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:43 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
+        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
+        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:43 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203183709'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '546'
+      Etag:
+      - W/"222-273e1966"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:43 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=3ec39b354cf38f4c1776546060ebfb420aea4fe33b965c9476cbd8bb8f4407ad; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:43 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
+        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
+        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:43 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/lists/58495b7d44db45802c4a9b6b/cards?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203183995'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"a0bDA6HDgBTkFuVDFPcyKQ=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2444'
+      Date:
+      - Thu, 08 Dec 2016 13:19:44 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=03e0c300503029d89a73294032040badefa86ba70839b1f80aa6e294ef8f283e; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:43 GMT; Secure
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1YbW/bOBL+K4T7pS1MW/K7DRwWbdJ2u2jStG66i22KLCVS
+        FmtJVEnKrrvof78ZUrKdommSu/SaBQ7wB5niDIczzzwzo3d/tyRvzVrDyWA6
+        jMZ8MODRYDgJevGATaMRb7VbcSri5XMr8rllVpjWrKiyDJYzZQSIJiwzot3i
+        8O4FM/ZRbOVK2g3o7AXhiIY9GkzehP1ZMJ31h51wFP4JOrkwMeyonw6ZZY1a
+        yR8rpp1J4wnnSQwSbDIeDYPBpD/mwShu4aYX0tjLzY7cniORR0Kbt8qine/e
+        49o8VRoEe+Me/ntkLYvTXBT2QK2EbmzIWVGxzC3tdmxvCoezSGTgiHeX2Djp
+        teCwguUCTDxkMtuQeayrnDBLwnDWD1jeJh9YsVCVNR1TGdHhok20Ujk5ax1k
+        quLkqaoKrjdn6KNSwWE9UB60WwYv8EIWS1B9+vLt6z+i6CNsiRhfYGz+bq2U
+        CxJsXUmxlsXCu6H2Qn0HU0Um1jLaW0rUIqoWn31UtjH3mnZ/D/AJpXBV5egY
+        v4VtHeX/Y1y1LK1UxQ4jlWhcDI8HKi8zYUX9+su3Fi/ISO5OzyD0polnHWP/
+        N2vi0oD6suhcE2Z1BOdWxssNekVlCkDSijIwqt2CuMFhk/6X93VYTnUGb1Nr
+        SzPrdq0WWaY64KVu3N0L1Td8X10t2AXIUo5YogaxRJmlYUgRS7SBEkUoUS4o
+        IonGiCOaeBy1vrS/n+ni9jN9cjcyvf+/yvQ3guUzwiIF/m4TxqskAX/CkzI2
+        VUmbxCkcKjQ8GHgEDshZrjTLhIFHMKVQbWJWKsuYTdvEpuAdULAlgOEo+IoA
+        Hoevjt/KT3/+nwDuPAHshepmBNAIAgH0qQWIUY8w2gCM1viiNbyoRxfdgot6
+        bNEGWnSLrKtIIbl1Upjul/83qYAUMFZoEmlWxClRCcAeF+NUFkJviBaAfWkV
+        PMasIJEgsiB2rYhx1szOirPiIXn48KylSlGctR4+bJN1KopGrzQEX5BEaVKI
+        NYkVF3CEVtUiJbnQC8gPUsKN4KSPlQBgEa8u0erzJQoj4YTANKYFd6oZiGeC
+        GUFYwUmhiIJraEh4YGZhCOwjDEK6hu3gfLhBCt4DvQoujspq5c6pmli1Vcii
+        TPi7kvuyIzqohgDuNF1JI/Hl/hngEUhyEm2IJzby6pEzCIWWhVoXjZkU8Aeg
+        hh2Q8l42kZ8Ef9BBh54a4cLw1xFbCuLY8S+SAeXA1eESaJ8R1m1xpjmhe/fu
+        EeBQwHWFOW9wrQE0EgUsddZyKXPBJesovejiv+5TmYnZ81ica8X4uSzOQev5
+        MeRSuobLnL8RWmP4pTDnlHU+lIufWEkG36wktcJJcFFhhMlzSX2xurpWeRlj
+        /32NyuNSE5PH46ipGGEQjPq9iyVjkbOTqV39dudKRv+rkuF9dDcqhovDTSrG
+        acEhj9cQFQ15I/ZKxwapfb0tHuFwx8F3p1jtgeRmxaoRhGI1oI4bKBSmGpVX
+        VJtxePvVZrpXbZCf4liUFioN0CbQitCS+QKClQiQTKJMxUskZC7KTG0QmphW
+        R9KyJUPux3qkkWOBA5H/XJNNsCx7DiTHmEr43Khcsz0pGAAbv2HiSKjHfv5D
+        90FU1uew3IkX8hfJ/xUG4aA3mvxEwhveRuu8o6mTcEbuhw/Ia+eOxqtw422L
+        G4aTcDjo9KajwXQwHfVHF8kr//X3zx/mh89/LHn1riav8Ip+90eQ12Vpw1vf
+        obVrJPueU2+W7I0gJPuQliENqcc5zV1gKQb2qpzv3XbO94LBXs7vZZvMePOp
+        pVtq9UHE1mVc91CsRDZzX11m45kHZZPAu/SuO1TIYZX4JrWGb9P4ycK1bQa7
+        QqzGu861Q34X0Hx60sixpTIVNmspsIG0rq81FqgAu1vPO4LXLdX3GYtDR2eh
+        oWraZrMBns2RpmKlNJcFQ85ZS5u61wcnz2um8uKPX85/dYsNvRXGnwQK1ko7
+        HgTyEp9K8BWSV+I6dbHjR+x+tcrh2s1+YAMDGdBYtPVR44v6bO0OYSQBr0Qs
+        XpJMqXLP0p3bYdipfKuphakya1DDs9dPwKEWD8W7ggeqWvrozSmeHQ6D4GtC
+        fheGHfghaN6Tg0prSN0MOuWlDzJX0EQXykJwSkdPNq353lveBqJyhjS2708N
+        fshYpxJmGMa58cJJVcTIBywDvO5z/wJMrSKXRvPT+RPq7ttllVU5Q4Eu6u6G
+        g36AZo93Zp/sn4nv0RQcYyASDoC+1Hbg1lvEVXU3X49YrNjAXIg9+wXNj7Hy
+        gQDwDwo1lsoi0axTVGJXpuYiS+ZCr2QsuofSlBnbdFKbZ1iyhtNg2ENnH/n5
+        A2wSmjkn+CnKcyQURQmTlhvK3ECm6snOTzpaML5xox3FxVirdcQ0qeRMixwK
+        jrsOCuIGN4mAvILQrSSE5ZNb1sKt+F1nxUuHa4vu4tLEWLUE/8YJbkyL0QjY
+        zBBchdUq256Ghju7pTvVn/KNFy6XsuwSV/hMclevN7qwwwxWSJM2hsGgZElX
+        2LhbcbHq6gpm+Q7vjgNaYpZBoAtLIQ067o2LGgPnxAqgHSOvaO7y16YBqgNc
+        em1AE3CtRC66dQ51ZRInC4obt1qci/1rr+lCmgFlydK5uSpgspQJUqXEbkmD
+        YxfSTbNq59jGfbEqYZCH+CKfLMUGj3M2AbMmXa+iUwKHgWwjg0fg6/oE9A1G
+        RQIovTEeUz+xTRr9yC+M070576QHDdTkAXkmtt0TRIQtGGD4PtNxZbpQy6r8
+        wa6h6g+G/cmlDdW4r5+94k8OfmxDNbi6oRrenYZqEnyvofr+sDa94bB2wiR+
+        /7kwrTH3ybce14bXGdf2onizDq4RhA5uRMsendCF2LZvVUkdsqgDFnXAurKf
+        G9x+Pze55gx3LNYWaAOLdlUU2IyooqaxNcEvnmv8zOWZr9KOcFHsUMUVgs4z
+        MEhXJZrG8d3B/mZ8Z2vqcpUB6Qnkj+fENyLI/njetjeq+zH8Aod1pz7Iq34E
+        hZxpKxMoCcaVdNl8TNybPdHiHdlDt8JWTGbuoyDuhO5EK17FeNndyU5S+rsn
+        lYVe8z/umXY+haBBe4sfnOsvjP+kOXZ8y3PsCGh4+IAcOneTl9D7AdShi63d
+        hR7Dag+Nn/sk2wDhfikzARwtC0ioHUf3giAYXz70fpxHT4e6OPqxHD38Rw29
+        k+F/OfTuOfVmlNkIAmWOaTmiQ+qTjuIEYBAF0JIhCij8GhRQRAH1KKAeBNSB
+        oPXl/b8BE08s44IhAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:44 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b6d/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203184247'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-dcfd41be"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:44 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=063951a503e5d4936713ea2c62ca4452d847620873cb46e9dedf27240b157e6e; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:44 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:44 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b6e/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203184526'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-dcfd41be"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:44 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=e18cb59671dbf61a64f508cf7fd3761b6d5ae37124f015960ae8d6b1ec46fbc0; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:44 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:44 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b6f/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203184754'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '236'
+      Etag:
+      - W/"ec-3965fc28"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:44 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=449d73b8edaa4e54041a2548c34960f81600e9d84dde78cd7414d775c7cc9a62; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:44 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
+        waterline","color":"yellow","uses":15},{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:44 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b71/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203185022'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:45 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=1b39cb77e70524fb6f5728371a623cc7566f6b6835e0bb382d80eb55581e691c; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:44 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:45 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b71/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203185321'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:45 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=80a819aa1848cd603fe2411827ac2231699fcbffa59c343f34f4043733977412; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:45 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:45 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b71/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203185696'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '948'
+      Etag:
+      - W/"3b4-504c3a98"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:45 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"58495b7d44db45802c4a9b71","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":2,"checkItemsChecked":0,"comments":1,"attachments":0,"description":true,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T13:19:45.637Z","desc":"##
+        Acceptance criteria\n\n* The bug blocking deployment of Mitaka is reported
+        to the cloud team\n\n## Notes\n\nThe bug was reported at https://bugzilla.suse.com/show_bug.cgi?id=1014268","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":["58495b7d44db45802c4a9b7d"],"idLabels":[],"idList":"578e03cf104153b060cc27bd","idMembers":[],"idShort":199,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[],"name":"P1:
+        (1) Report Mitaka bug","pos":360448,"shortUrl":"https://trello.com/c/mHWzjSDI","url":"https://trello.com/c/mHWzjSDI/199-p1-1-report-mitaka-bug"}'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:45 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b72/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203185932'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '115'
+      Etag:
+      - W/"73-6446cd67"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:45 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=f57dc2860c960463a326cd3592c0bb1a05dbb2b77d93f902c91aae1e7597ca01; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:45 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d089","idBoard":"578ddfc161a876504837d06c","name":"Pairing","color":"black","uses":85}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:45 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b72/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203186186'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '115'
+      Etag:
+      - W/"73-6446cd67"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:46 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=f42623b0f401c3bc19a021a88326d46f3120f998c321302268afeb0614299fe0; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:46 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d089","idBoard":"578ddfc161a876504837d06c","name":"Pairing","color":"black","uses":85}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:46 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b72/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203186600'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"2J8wr5u2UneKQq7TdDtamg=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 13:19:46 GMT
+      Content-Length:
+      - '1286'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41W247bNhD9FUJ5SYrVxVd5BRRFsgnSANlm201aoMk+UOTI
+        Zk2RKknZcYP8e2coadctsmgBw5CGczlzOBd9SZRMqmS1WV6u6lIul7JerjbF
+        XCz5ZV3Ok4uk5nILPqm+JAcb6KG4SA4Kjspsr6Gtwf2KYvTRcO3hIvF97YVT
+        9Zmosdu63/6FYdCd2IHYvwnQoqfl+esVPZEV+he2bcEEVFldJDwELnbjOx5K
+        oABdUNYkVXA9RpA9JJXptY6PV7btNAQYAXw9i3IbeMzh4x0KtfVnKCWevOU+
+        PBdBHVQ4Idx5MVuns3labN7PFtXsslqus+Vm8XsygEANtguh81We173SMvO9
+        h0xC3jn7B4iQ+5095i/hALq60raXVVldq8D3/JP5ZN7vgAmSsgC8ZbXjBnFK
+        ZpuGBTwbNJkDDdwDUyZYxpmHjjuEivLOehWsO2XsN2AG0BQ1Wr4H5nsH6IMH
+        pgIT3DAflNasBiah0/YEMiMET56w50JAFzAyYnEqgFMR23eM0El7NEG1gJAi
+        In/yyCFTnglrnVQGcUh2VGEXj69u3sRUJvMX725/jMIxE2X8EAkdHK3bYwUx
+        7hl87pArdMQbjI8gST7hZI2zLaY96R/Aebz4CdE9RxMXY2wXg3DWICs1F3um
+        re3OkD7Qzmvbhyh04HsdPHl4/csrJDRQUMoVGehH6+v3Hyj2bFUUI4M/UVfQ
+        88fZLMMfFc0du+qdw4rVJ9buh0uWFjwzNuDldJ11FBMhPiC/YPUAZMLeYT3j
+        +Z89+MBsB4Ydd0rsGJfSD8ZNbwS1AddYrwxve6rGLULt6wyR57cfbl+lMd+c
+        98G2nAxy8p3PlouCYJcPsG/OY9I5QWnBbfEmYgG22CHgMsz6vuKw5iN/QwEz
+        bk6tdZD9y/MLbam9GfYnGU1IlWkcz0wPQ+9ExKCbW3AHJSB/qXyn+SnbhVb/
+        oOT3q8tiNSeyr7npuSZM4HgkAdlBiobRwI5cBeTHOmRcxoA1dRD2wdA6XJ4q
+        cpOSUDh7rLljvaoctPYwpEOGpOAhRHuLV3dQeC2fo9hBlAxan8y7WNeB6JLK
+        C3TiQH4jAuMaiSAQqMypuExwVt9HI+ARt4pRhyjfOIi9pPUjVAydFFMfFeO1
+        s0YZ5XcTMJDoK4cg8l7CIXe9Bp/JvCzSjroML9qEFNsgiyfx1jiSIyyWtqC5
+        4mTs37AryB3W5eANxwSm1ahtPvZQrhrRbFNSvPcSKR6OB0//aDMcWaqLNPeG
+        7Y1qaFQqxIOMONgSNsfsA7ETfcJ2JxRCHEx7OFG4iAkna5MPLrIOZxjaTjYU
+        go7HCMQN3YrCohzADDU1Dv2XPPCzXfP42rlIoOVKTwpKvrCYJu3asqzXsIai
+        kLPFbMHXG4l/BU9IKW5BjfnRknpkLW+K5I503/Ia9KBXboQEMdssYV2WjVys
+        N029KlejHrqLcTdQLEQzK5az1aIu1oUQ87KWMe6wysfNqOTtDidUUs2Lgt6e
+        32/gKyrsKaU2Fl4UPWjcZ68ndF/GT4zHMP5PbgxvkdrkhiuHi4C+JKy2iCWp
+        NQ54fMf5QR8My693D8rzij3dPGOvsYfHVYEVxrcce/Ipd6L3Oe7mvn2G5jiH
+        k2pRrjeLOX7FUP4fHN5eMk2qgItY2zihRF4u3Ouf5asrCvvfWjnymHbzdJNu
+        IaRtBJL2XRqBpBFHGnEkX/8Gjy8ukJAJAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:46 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b74/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203186822'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:46 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=0bf5dfafdbb205af84ea8c1fb37b68acc9f90b99d2e706267950aaeaf9b74ddf; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:46 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:46 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b74/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203187115'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:47 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=5893bbda413c46449abadf0d74ffe7cfe5c1ff56af53f71c56864ac1e13000ff; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:47 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:47 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b74/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203187562'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"fcUmbT0zepwcH3qd6LwBcA=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 13:19:47 GMT
+      Content-Length:
+      - '742'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4VU22obMRD9FaG8JMVr79q76wuU4iZtKSRpqZM+tAlFK83a
+        IrK00cXGDfn3jnbtxC+hYIwuc86cmTnaJyoFndFikk+LaizyXFR5MUmHPGfT
+        apzTHq2YWIKjsye6MT4u0h7dSNhKvbyCdQX2Jx4jR82Ugx51oXLcyuroqDbL
+        Kiz/Yhqk4yvgD189rJGpON6ex1VEIT836zVojyFZjzLvGV/t93gpICZovDSa
+        zrwNmEEEoDMdlGqX52bdKPCwF/B8lGXhWVvD73s8VMYdqRR4c8mcn3MvN9Lv
+        UO4wzcokGybp5CYbzbLpLB/383H2i3YiMOLkhMw5h8YzzYGgLA9Wsjt9p9+R
+        a9h6o4l0xAatsV0Ed34FRMOWrJgVW2YRY3Qtl8GyWE+EXRgeYrHtQUSHJkoT
+        8e78ODjeeQvxjjCHRAJa/PWCbI19cKQ2ts0noFFmh1Fu57AHhGkRsWKfqKOe
+        K0WY9bJm3KNieAzSIiRydPgYSqLiBqyTSKS92hG2YVKxSkEbaaGxRgQei33N
+        3CJlV3sdfLCtzi8/PmEnfCcVBw5YKNlKvyJXN7fE1CQr0jR2Ent8HZ0X1689
+        xaEZwuoaeKy/2pGV942bDQbRalIp1nfBQR+JB25ltn/wuM+X8oMU77M0y4fl
+        ZD/FC+bZkXne9lGPwhqLPQRI8dHgEOPjGY+rEkpIU5GNshErJwL/UkZjUGtr
+        hf2KrnvjnU0Keh9jL1kFau9O3CGoZZ9AOuJ1luZZMarSMuV8OK5Ey969wBfI
+        YmUsYtC3cTd/eTjnZgP2IHzNdGCqPXqNeKlRHWnQbI3F0+/ljJwWZ+SinSb5
+        1oDGd8QfDg6PA0EbWc0UwTn5g89OG6kguIHUPLgz1NsYJB5NR8OsxA9F1Hpr
+        sZ/0MDp0s1KmnRkfPC6qz4XVV4gL/48aYM1JUyZF0nkuMajSRZWJblUm+Duo
+        TKLKpFOZdCKTViR9/geFI9AfEAUAAA==
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:47 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203187826'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '546'
+      Etag:
+      - W/"222-273e1966"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:47 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=05776f7e9fbf6a0cbee4e6d27587ddd74fb19751aaa1977db879553af1cf7b0c; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:47 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
+        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
+        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:47 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203188092'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '546'
+      Etag:
+      - W/"222-273e1966"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:48 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=f59e544316fecf33a84516e2265807af5b76dee9dfae2b1c61658ab4f12ddcc3; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:48 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
+        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
+        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:48 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/lists/58495b853ea992256749003d/cards?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203188347'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"IJIJu+DEh2ZzZl81HB32og=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1481'
+      Date:
+      - Thu, 08 Dec 2016 13:19:48 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=697351944a684ba5b6dd2627b6a908f95bd8f237be9d0b360fe8a71fe3734196; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:48 GMT; Secure
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1Wa2/bNhT9K4T2YQ9YlvySZX/Lsg4IkHRpk67FmgKlKMrm
+        TJEaSdlxi/z33UvJr8Jum61b92FAEFgS7+W59x6ew9fvA5EH02CUDiejLB0N
+        OJ1M+v1RMh5O4ngYB52AzTlbXDhe3jjquA2mqpYSXkttOYQWVFreCXL4dkmt
+        O2NOLIVbQ85+3EvCXj+M09veYBpPpsO4O5okv0HOnFsGK8IwvFP83nGjqJwS
+        Z2p+p4Q6fLaMbX62kT9RRzcwRP6jpsaXME7zvGC9pEfTcTKKh+lgnMcJC3DR
+        pbDuZJmD3K+54mXGjf1VO6zr9Rt8dzPXBgL74wk+nTlH2bzkyp3rJTe7hOPD
+        hKMMEpZU1VT6hbu4YIqVeEQ04xK6+foE8LQfAAJFSw7b+NYTXZALaM7MUCe0
+        IrfcOgsbVRrS9Ebj0SBJu/EgjvvDcdIJLEK/FGoB8em7Vy+pnp3B6ozmM5zi
+        +2Cp/TjjTrAUfCXUrGlAW387V1tnlhmR7b0q9CyrZ+8g7T47mky7x3P8hVH4
+        VpdYfLOEbpsBz/1mokZUWNKmO3nNN/OFn+e6rCR3vAXwcOzlQYzI/eZSYH/a
+        QbbDbR7lpvcb9p+awGfyazslwRZrbIqWGtmRSQDVCWqLfU4HD2/aqbwwEr7O
+        navsNIqc4VLqLjQpYtHepI60vv50YARcDS3yJdRFKHZ8CZ3ny0Pno0d+UHzx
+        I59O9o787ZyTkgpFaL6kytGZpzW/r6Bj1GmzJggTyEiEJW5OHZHCOclJZXhF
+        W+bDJ8V5zvMOEWUFDYVMBDhpCTWcFLpWOfmjhmHIdYdQeIA0/J6z2kc7UfIO
+        5OaEVpXRQEbYU+WwnSYZoNOQA/smJWcOjrBcE0BU1pJ6XABK7WUD9A1/ee6h
+        2+6dulMv51yRta4hkhqHmZsSud+X6Rxg0lpRELa1T6pJIQCoLwKUY4EPc4p1
+        gn4QyyFdxgtI0CHMcFQDCt9WhAE5oWJDalVJqhSgWGmzwITOULZAEIb8Dv8U
+        X3toV019EFM23aSZrt3RETCKu7YNhZlhqpVYiCnm2bBwJty8zjwLb17cPImo
+        LAzPI1wXPdklDW+bpBj6FXU8/aiOJx/oeHJax9tD8Egh32sIaRuyUfBBbxSP
+        B0k3TsB4J6P+oYJfJTP27pq9+s8peO9/BT8U4r1JPU7BN4Gg4Gm4dxzD9jh+
+        SrqHvS9/Wxt+IN1LKkWOqFoFpBlIM+pUhgqFUgwCVBhdEjuH0lCGntfZuksw
+        +Pn1lV/b6CzNqRdNFC8U+g6xmghHKgBsUW0MBw0HKSEzICPhjnn5wkS4D5oA
+        q40BFoJAo6H4SB8F/ZqSI/oEXahzr2bQVaFYnWEpEStCXXEFUs0W4bbCCNNF
+        wy55yaEYXcu8gewVvIKl3rsUQ0kHLPBXcjMDuGg4MFdOoeMe8jffkDPGeAU2
+        BauBEHDBFdSL6A/kF9BUbAyMGNBntZC5xfeH3W6+orKDx9nWCsgKXUYgcPCq
+        tu976DDN2zBklQhbPG8RZkUdsCTfjAFk3R9dKgkabAlH0nTJRUGUhmEYvRQ5
+        Loa059cXx3ZD1d82BF2bLrjqtpsjZOBumMMkGbL57a4KgQKAMgLZ6srCYaAl
+        +Iub+7T8HlvmDRuvAcCMXHOrvnVgn3BxEKq10rISCAfAwW2g2A7DozgOcjOU
+        pyifnlPaWx7uAZel7GDCmGFHJj+frmcLaEJXm1nULoyAI6voHBk2vdVa2hO0
+        +prul8ZH3a/B8Hd9bowYT+jwZM8Cr0dT8t3ge3LmD9PxJm27DxzFWw5qCDm/
+        vNh6Zb+X9Mf9E155m7mfn/Wfr/5Zrxx+2iuHH3hl/C945SlzSIK/6qJj9kgX
+        fQp3c0uene356MyAP2yNdLBzslN8edyO11SY5iq1M25g0M65h5/j3Hu8eZxz
+        bwIjOGFhNQoHoXeK8Di5w5bcodMhkDs0QO6QSRE8vPkTuniuxo8RAAA=
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:48 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b853ea9922567490040/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203188614'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-dcfd41be"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:48 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=6cf04394c232fdea3d2b9110696342e2f32b0cc2e1b4822049df92cc4063c421; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:48 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:48 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b853ea992256749003f/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203188853'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '113'
+      Etag:
+      - W/"71-dcfd41be"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:48 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=2c9cd20c024ad39533ed0d9785f2ce43dd981c55358bc7b9086bc645b738077a; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:48 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:48 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b853ea9922567490041/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203189100'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '229'
+      Etag:
+      - W/"e5-571096d0"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:49 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=d412942b4124d70a7e8e56023ff33730493e59cb6bd54679a77f2d01b408fe08; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:49 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07c","idBoard":"578ddfc161a876504837d06c","name":"Needs
+        QA","color":"green","uses":3},{"id":"578ddfc161a876504837d089","idBoard":"578ddfc161a876504837d06c","name":"Pairing","color":"black","uses":84}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:49 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/cards/58495b853ea9922567490041/labels?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203189379'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '229'
+      Etag:
+      - W/"e5-571096d0"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 08 Dec 2016 13:19:49 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=2b07d33dc7b0c5177113396b317c06abf9fc6ddea823ce7f727c576e30a287ef; Path=/;
+        Expires=Sun, 11 Dec 2016 13:19:49 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"578ddfc161a876504837d07c","idBoard":"578ddfc161a876504837d06c","name":"Needs
+        QA","color":"green","uses":3},{"id":"578ddfc161a876504837d089","idBoard":"578ddfc161a876504837d06c","name":"Pairing","color":"black","uses":84}]'
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:49 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/58495b853ea9922567490041/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.823.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1481203189817'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"N0gQbVR9vrC1zgKVcSyU8g=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Dec 2016 13:19:49 GMT
+      Content-Length:
+      - '984'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA5VVaW/jNhD9K4T2Qw9YlnzIh765bgsEyG6zSXYX6CZAeIxk
+        IhSpkpS9bpD/3iF9LuCgLRA4PB5nHt88jl4SKZIyKWbjecFmxQjofD4cFpPp
+        eJ7n40HSSxgVNbikfEnWxodB3kvWEjZS1++hYWA/4zLGqKhy0Etcxxy3kp0t
+        VaZmXf03psFwfAX8+cpDg5HG59NlGIVTGJ+bpgHtdxDqPeWr/Rw3BYQErZdG
+        J6W3HWYQHSSl7pSKw6VpWgUe9gRez7LceRrv8PURF5VxZywF7lxT5xfcy7X0
+        W6Q7zAeTdDBM89n9YFQO5uV43p/m0z+THQlE3K+ArKmSeNhYAt+Ad54yBWRF
+        HWEAmrTGojyksqYhbgVKEW/Ibce2fRIO3968j1hcZECooG1EYzC/or5HnCHS
+        kxav5ojUxMJfnbSIqFExAp73H/SDDoFCHiId4Z21KJXaBjiNJ+MpcL4kK+9b
+        V2ZZLf2qY32UOUMVOlGZTgu7TaXmHQtXyXiVmha0Q+mf0+MNsxAuG/fJF8DL
+        mE6JHWUkiwwQSmsgRnPABeSCfw3YGulSLZCFAoqKR8rv3pEF59B6GtBYTw9W
+        0jJs/Uz+6GwUxnmJ7FknlXBh/Xu1d7sbY58diWqjakA2KxRdBuJKHXQ/YxfC
+        PKUpb2W65/MUaLbUo0fEoQyamOgvqnDH0gbNZPvkqiLaYDGsWUsRwBh2eXN1
+        Kdvdp7vfjoJgfE+fQff3yQNlfD2pwEpyvMn26XQLGawbvI7RutZ5C7QhGyxX
+        DAvfgmRILLojOEMYcPoHT7jRnkodUVjWVgY6SK5HZHUsRmRxmeShKB/CG4+e
+        MgRHMUdtKfuuwiHCyUyxPv3ols5B39g62wMz9MgmWwaHlffGKPeGrR70/kX9
+        Sj09e8hvv+leAg2V6gCQ4hdDbWxk0ymbwATyXAxGgxGdzAT+5DQJoNhilHSh
+        kXx9q+dNkseAvaYM1AknKvwHk+m0EqMJZXMoBIYspjMugA9OW7OKFdNiHwIz
+        RUozyEe8GmA/LUYsn+ScD6dMREq7FrrvSFLcrfAZJ+UwH4bZ4tj5lmYN9nDb
+        huqOqrh0QhyFUQfiL/vW/hbH/yibRvsj4oZKi6YNHdwog1wSprCIOMeiY7qi
+        eO29nH1MLgv2fzJ+ABCOfFycpawtttRjysHr44leUZIfRz+RRWxHl2129C++
+        cg2b2IXJ8voKA7YmfGvy+STHD4wLRfhk0V3JweP4DpUyu4aZ3TP/+8fh7SYQ
+        +XdUhsVM2yIdpbFVppe5pXtuqTcpckstcku5ksnrP/LXJrGiBwAA
+    http_version:
+  recorded_at: Thu, 08 Dec 2016 13:19:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/data/vcr/sprint_cleanup.yml
+++ b/spec/data/vcr/sprint_cleanup.yml
@@ -579,7 +579,7 @@ http_interactions:
         Expires=Sun, 11 Dec 2016 13:18:36 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"57ab15db6568cc9735820ee3","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84863,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
+      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"57ab15db6568cc9735820ee3","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84863,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready for Estimation","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
     http_version:
   recorded_at: Thu, 08 Dec 2016 13:18:36 GMT
 - request:
@@ -2344,7 +2344,7 @@ http_interactions:
         Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"57ab15db6568cc9735820ee3","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84863,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
+      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"57ab15db6568cc9735820ee3","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84863,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready for Estimation","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
     http_version:
   recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
 - request:

--- a/spec/unit/card_spec.rb
+++ b/spec/unit/card_spec.rb
@@ -23,49 +23,9 @@ describe Card do
       expect(@card.story_points).to eq(0.5)
     end
 
-    it "extracts priority number from card name" do
-      allow(@card).to receive(:name).and_return "(0.5) P1: Refactor cards"
-      expect(@card.priority).to eq(1)
-    end
-
     it "extracts story points when value is not at beginning of card name" do
       allow(@card).to receive(:name).and_return "P01: (3) Refactor cards"
       expect(@card.story_points).to eq(3)
-    end
-
-    it "extracts priority number from card name if it is at the beginning " do
-      allow(@card).to receive(:name).and_return "P01: (3) Refactor cards"
-      expect(@card.priority).to eq(1)
-    end
-  end
-
-  describe "updates priority" do
-    before(:each) do
-      @card = Card.new({"cards" => [{ "id" => "mycard" }]}, "mycard")
-    end
-
-    it "updates existing priority in title" do
-      @card.name = "P01: (3) Refactor cards"
-      @card.priority = 3
-      expect(@card.name).to eq("P3: (3) Refactor cards")
-    end
-
-    it "adds new priority text to title" do
-      @card.name = "(3) Refactor cards"
-      @card.priority = 4
-      expect(@card.name).to eq("P4: (3) Refactor cards")
-    end
-
-    it "updates priority after story points" do
-      @card.name = "(0.5) P1: Refactor cards"
-      @card.priority = 4
-      expect(@card.name).to eq("(0.5) P4: Refactor cards")
-    end
-
-    it "adds priority after story points" do
-      @card.name = "(0.5) P1: Refactor cards"
-      @card.priority = 5
-      expect(@card.name).to eq("(0.5) P5: Refactor cards")
     end
   end
 

--- a/spec/unit/scrum/prioritizer_spec.rb
+++ b/spec/unit/scrum/prioritizer_spec.rb
@@ -8,38 +8,17 @@ describe Scrum::Prioritizer do
   end
 
   context "default" do
-    before(:each) do
-      full_board_mock
+    it "raises an exception if board is not found", vcr: "prioritize_no_backlog_list", vcr_record: false do
+      expect { subject.prioritize("xxxxx123") }.to raise_error(Trello::Error)
     end
 
-    it "raises an exception if list is not on board" do
-      expect {
-        subject.prioritize("53186e8391ef8671265eba9d", "Backlog")
-      }.to raise_error("list not found on board")
+    it "raises an exception if list is not on board", vcr: "prioritize_no_backlog_list", vcr_record: false do
+      expect { subject.prioritize("neUHHzDo") }.to raise_error("list named 'Backlog' not found on board")
     end
 
-    it "raises an exception if list is not on board" do
-			RSpec::Expectations.configuration.on_potential_false_positives = :nothing
-      expect {
-        subject.prioritize("53186e8391ef8671265eba9d", "Sprint Backlog")
-      }.not_to raise_error("list not found on board")
-    end
-
-    it "adds priority text to card titles" do
-      [
-        "5319bf244cc53afd5afd991f/name?key=mykey&token=mytoken&value=P1:%20Sprint%203",
-        "5319c16d9d04708d450d65f1/name?key=mykey&token=mytoken&value=(3)%20P2:%20Fill%20Backlog%20column",
-        "5319c57ff6be845f428aa7a3/name?key=mykey&token=mytoken&value=(5)%20P3:%20Read%20data%20from%20Trollolo",
-        "5319c5961e530fd26f83999d/name?key=mykey&token=mytoken&value=(3)%20P4:%20Save%20read%20data%20as%20reference%20data",
-				"5319c5a8743488047e13fcbc/name?key=mykey&token=mytoken&value=(8)%20P5:%20Celebrate%20testing%20board",
-      ].each { |value|
-        stub_request(:put, "https://api.trello.com/1/cards/#{value}")
-      }
-
-      expect(STDOUT).to receive(:puts).exactly(5).times
-      expect {
-        subject.prioritize("53186e8391ef8671265eba9d", "Sprint Backlog")
-      }.not_to raise_error
+    it "adds priority text to card titles", vcr: "prioritize_backlog_list", vcr_record: false do
+      expect(STDOUT).to receive(:puts).exactly(13).times
+      expect { subject.prioritize("neUHHzDo") }.not_to raise_error
     end
   end
 end

--- a/spec/unit/scrum/priority_name_spec.rb
+++ b/spec/unit/scrum/priority_name_spec.rb
@@ -1,0 +1,41 @@
+require_relative "../spec_helper"
+
+describe Scrum::PriorityName do
+  let(:priority_name) { Scrum::PriorityName.new }
+
+  describe "parses name" do
+    it "extracts priority number from card name" do
+      expect(priority_name.priority("(0.5) P1: Refactor cards")).to eq(1)
+    end
+
+    it "extracts priority number from card name if it is at the beginning " do
+      expect(priority_name.priority("P01: (3) Refactor cards")).to eq(1)
+    end
+  end
+
+  describe "updates priority" do
+    it "updates existing priority in title" do
+      expect(
+        priority_name.build("P01: (3) Refactor cards", 3)
+      ).to eq("P3: (3) Refactor cards")
+    end
+
+    it "adds new priority text to title" do
+      expect(
+        priority_name.build("(3) Refactor cards", 4)
+      ).to eq("P4: (3) Refactor cards")
+    end
+
+    it "updates priority after story points" do
+      expect(
+        priority_name.build("(0.5) P1: Refactor cards", 4)
+      ).to eq("(0.5) P4: Refactor cards")
+    end
+
+    it "adds priority after story points" do
+      expect(
+        priority_name.build("(0.5) P1: Refactor cards", 5)
+      ).to eq("(0.5) P5: Refactor cards")
+    end
+  end
+end

--- a/spec/unit/scrum/priority_name_spec.rb
+++ b/spec/unit/scrum/priority_name_spec.rb
@@ -1,7 +1,7 @@
 require_relative "../spec_helper"
 
 describe Scrum::PriorityName do
-  let(:priority_name) { Scrum::PriorityName.new }
+  let(:priority_name) { Scrum::PriorityName }
 
   describe "parses name" do
     it "extracts priority number from card name" do
@@ -30,12 +30,6 @@ describe Scrum::PriorityName do
       expect(
         priority_name.build("(0.5) P1: Refactor cards", 4)
       ).to eq("(0.5) P4: Refactor cards")
-    end
-
-    it "adds priority after story points" do
-      expect(
-        priority_name.build("(0.5) P1: Refactor cards", 5)
-      ).to eq("(0.5) P5: Refactor cards")
     end
   end
 end

--- a/spec/unit/scrum/sprint_cleaner_spec.rb
+++ b/spec/unit/scrum/sprint_cleaner_spec.rb
@@ -8,7 +8,7 @@ describe Scrum::SprintCleaner do
   end
 
   it "moves remaining cards to target board", vcr: "sprint_cleanup", vcr_record: false do
-    expect(STDOUT).to receive(:puts).exactly(5).times
-    expect(subject.cleanup("GVMQz9dx", "neUHHzDo")).to be
+    expect(STDOUT).to receive(:puts).exactly(12).times
+    expect(subject.cleanup("NzGCbEeN", "neUHHzDo")).to be
   end
 end


### PR DESCRIPTION
I refactored the Prioritizer to use inherit from TrelloService. We can now use the same card detection methods as in the other SCRUM commands.

* Using the methods from the Trello gem we can avoid #46 
* Add QA list to lists being cleaned up by SprintCleaner
* Ignore cards with sticky label in Prioritizer and SprintCleaner
* Remove command line argument from Prioritizer
* Renamed 'Ready' list to match our board (see #57 for suggestion how to handle names in the future)