### PR TITLE
Fix name of the backlog column on Planning Board

### DIFF
--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -75,7 +75,7 @@ class Settings
         "sprint_backlog" => "Sprint Backlog",
         "sprint_qa" => "QA",
         "sprint_doing" => "Doing",
-        "planning_backlog" => "Backlog",
+        "planning_backlog" => "Platform Backlog",
         "planning_ready" => "Ready for Estimation"
       },
     }.freeze


### PR DESCRIPTION
The name of the backlog column on our Planning Board has changed from "Backlog" to "Platform Backlog", but that change was not reflected in trollolo yet, therefore moving cards from the planning board to the sprint board didn't work anymore. This commit fixes this issue.