### PR TITLE
Add total days and weekend lines as params

### DIFF
--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -209,9 +209,11 @@ class BurndownChart
     end
   end
 
-  def create_next_sprint(burndown_dir)
+  def create_next_sprint(burndown_dir, options={})
     load_last_sprint(burndown_dir)
     self.sprint = self.sprint + 1
+    @data["meta"]["total_days"] = options[:total_days] if options[:total_days]
+    @data["meta"]["weekend_lines"] = options[:weekend_lines] unless options[:weekend_lines].blank?
     @data["days"] = []
     write_data File.join(burndown_dir, burndown_data_filename)
   end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -166,6 +166,8 @@ EOT
   desc "burndown", "Update burndown chart"
   option :output, :aliases => :o, :desc => "Output directory", :required => false
   option :new_sprint, :aliases => :n, :desc => "Create new sprint"
+  option :total_days, type: :numeric, desc: "Provide how many days the sprint longs. 10 days by default"
+  option :weekend_lines, type: :array, desc: "Set the weekend_lines. [3.5, 8.5] by default"
   option :plot, :type => :boolean, :desc => "also plot the new data"
   option 'with-fast-lane', :desc => "Plot Fast Lane with new cards bars", :required => false, :type => :boolean
   option 'no-tasks', :desc => "Do not plot tasks line", :required => false, :type => :boolean
@@ -177,7 +179,7 @@ EOT
     chart = BurndownChart.new @@settings
     begin
       if options[:new_sprint]
-        chart.create_next_sprint(options[:output] || Dir.pwd)
+        chart.create_next_sprint(options[:output] || Dir.pwd, { total_days: options[:total_days], weekend_lines: options[:weekend_lines] })
       end
       chart.update(options)
       puts "Updated data for sprint #{chart.sprint}"

--- a/spec/unit/burndown_chart_spec.rb
+++ b/spec/unit/burndown_chart_spec.rb
@@ -436,14 +436,11 @@ EOT
     end
 
     describe "create_next_sprint" do
+      let(:path) { given_directory_from_data("burndown_dir") }
+      let(:chart) { BurndownChart.new(@settings) }
+      let(:next_sprint_file) { File.join(path, "burndown-data-03.yaml") }
+
       it "create new sprint file" do
-        path = given_directory_from_data("burndown_dir")
-        chart = BurndownChart.new(@settings)
-        chart.create_next_sprint(path)
-
-        next_sprint_file = File.join(path, "burndown-data-03.yaml")
-        expect(File.exist?(next_sprint_file)).to be true
-
         expected_file_content = <<EOT
 ---
 meta:
@@ -455,6 +452,29 @@ meta:
   - 7.5
 days: []
 EOT
+        chart.create_next_sprint(path)
+
+        expect(File.exist?(next_sprint_file)).to be true
+        expect(File.read(next_sprint_file)).to eq expected_file_content
+      end
+      
+      it "create new sprint file with params" do
+        expected_file_content = <<EOT
+---
+meta:
+  board_id: 53186e8391ef8671265eba9d
+  sprint: 3
+  total_days: 17
+  weekend_lines:
+  - 1.5
+  - 6.5
+  - 11.5
+  - 16.5
+days: []
+EOT
+        chart.create_next_sprint(path, { total_days: 17, weekend_lines: [1.5, 6.5, 11.5, 16.5] })
+
+        expect(File.exist?(next_sprint_file)).to be true
         expect(File.read(next_sprint_file)).to eq expected_file_content
       end
     end


### PR DESCRIPTION
Allow to specify the `total_days` and `weekend_lines` variables when running `trollolo burndown --new-sprint`. :bowtie: 

Closes https://github.com/openSUSE/trollolo/issues/77