### PR TITLE
Remove 'Unplanned' label on `cleanup-sprint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* Find and remove 'Unplanned' labels on `cleanup-sprint`. Fixes #72.
+
 
 ## Version 0.0.11
 

--- a/lib/scrum/sprint_board.rb
+++ b/lib/scrum/sprint_board.rb
@@ -46,6 +46,12 @@ module Scrum
       end
     end
 
+    def find_unplanned_label(labels)
+      labels.find do |label|
+        label.name =~ /unplanned/i
+      end
+    end
+
     private
 
     def under_waterline_label

--- a/lib/scrum/sprint_cleaner.rb
+++ b/lib/scrum/sprint_cleaner.rb
@@ -28,12 +28,22 @@ module Scrum
       card.remove_label(label) if label
     end
 
+    def unplanned_label(card)
+      @board.find_unplanned_label(card.labels)
+    end
+
+    def remove_unplanned_label(card)
+      label = unplanned_label(card)
+      card.remove_label(label) if label
+    end
+
     def move_cards(source_list)
       source_list.cards.each do |card|
         next if @board.sticky?(card)
         puts %(moving card "#{card.name}" to list "#{target_list.name}")
         card.members.each { |member| card.remove_member(member) }
         remove_waterline_label(card)
+        remove_unplanned_label(card)
         card.move_to_board(@target_board, target_list)
       end
     end


### PR DESCRIPTION
Find cards labeled 'Unplanned' and remove the label when moving
them from the sprint board to the planning board.