### PR TITLE
Prepare version 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Trollolo Changelog
 
+## Version 0.0.11
+
+* Add in `trollolo burndown --new-sprint` command the `total_days` and
+  `weekend_lines` params. Closes #77.
+* Change stdout output when running set-priorities to render the new priority
+  instead of the old one. Fixes #72.
+
 ## Version 0.0.10
 
 * Rename `sprint-cleanup` to `cleanup-sprint`.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module Trollolo
 
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 
 end


### PR DESCRIPTION
- Add in `trollolo burndown --new-sprint` comand the `total_days` and `weekend_lines` params. Closes #77.
- Change stdout output when running set-priorities to render the new priority instead of the old one. Fixes #72.