### PR TITLE
Fix missing 'require' for FileUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (unreleased)
 
 * Find and remove 'Unplanned' labels on `cleanup-sprint`. Fixes #72.
+* Fix `trollolo burndown-init` and `trollolo backup`.
 
 
 ## Version 0.0.11

--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 class Backup
 
   attr_accessor :directory

--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -14,6 +14,8 @@
 #
 #  To contact SUSE about this file by physical or electronic mail,
 #  you may find current contact information at www.suse.com
+require 'fileutils'
+
 class BurndownChart
 
   attr_accessor :data


### PR DESCRIPTION
Include "require 'fileutils'" in the files that call the FileUtils module.