### PR TITLE
Remove Ruby 2.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Find and remove 'Unplanned' labels on `cleanup-sprint`. Fixes #72.
 * Fix `trollolo burndown-init` and `trollolo backup`.
+* Remove Ruby 2.1 support. Closes #96.
 
 
 ## Version 0.0.11

--- a/trollolo.gemspec
+++ b/trollolo.gemspec
@@ -12,13 +12,12 @@ Gem::Specification.new do |s|
   s.summary     = 'Trello command line client'
   s.description = 'Trollolo is a command line tool to access Trello and support tasks like generation of burndown charts.'
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.2'
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'trollolo'
 
   s.add_dependency 'thor', '~> 0.19'
   s.add_dependency 'ruby-trello', '~> 1.5.0'
-  s.add_dependency 'activesupport', '~> 4'
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact


### PR DESCRIPTION
It is not working and this allow us to remove the activesupport  dependency.

Closes https://github.com/openSUSE/trollolo/issues/96.