### PR TITLE
Prepare version 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Master (unreleased)
 
+
+## Version 0.0.12
+
 * Find and remove 'Unplanned' labels on `cleanup-sprint`. Fixes #72.
 * Fix `trollolo burndown-init` and `trollolo backup`.
 * Remove Ruby 2.1 support. Closes #96.
-
 
 ## Version 0.0.11
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module Trollolo
 
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 
 end


### PR DESCRIPTION
- Find and remove 'Unplanned' labels on `cleanup-sprint`. Fixes #72.
- Fix `trollolo burndown-init` and `trollolo backup`.
- Remove Ruby 2.1 support. Closes #96.