### PR TITLE
Run burndown generation on `cleanup-sprint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add a new `plot-to-board` option to the burndown command to send the plotted
   burndown chart to the first card of the `Done` column.
 
+* Run `burndown` on `cleanup-sprint`. Fixes #68. 
+
 ## Version 0.0.12
 
 * Find and remove 'Unplanned' labels on `cleanup-sprint`. Fixes #72.

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :test do
   gem 'ronn', '>=0.7.3'
   gem 'rake'
   gem 'rubocop', '~> 0.49.1'
+  gem 'rspec-mocks'
 end

--- a/lib/scrum/sprint_cleaner.rb
+++ b/lib/scrum/sprint_cleaner.rb
@@ -8,6 +8,8 @@ module Scrum
       @target_board = Trello::Board.find(target_board_id)
       fail "ready list '#{@settings.scrum.list_names["planning_ready"]}' not found on planning board" unless target_list
 
+      gen_burndown
+
       move_cards(@board.backlog_list)
       move_cards(@board.doing_list) if @board.doing_list
       move_cards(@board.qa_list) if @board.qa_list
@@ -45,6 +47,18 @@ module Scrum
         remove_waterline_label(card)
         remove_unplanned_label(card)
         card.move_to_board(@target_board, target_list)
+      end
+    end
+
+    def gen_burndown
+      chart = BurndownChart.new(@settings)
+      begin
+        chart.update({})
+        puts 'New burndown data was generated automatically.'
+      rescue TrolloloError => e
+        if e.message =~ /(burndown-data-)\d*.yaml' (not found)/
+          puts e.message + '. Skipping automatic burndown generation.'
+        end
       end
     end
   end

--- a/spec/data/vcr/sprint_cleanup.yml
+++ b/spec/data/vcr/sprint_cleanup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/NzGCbEeN?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/7Zar7bNm?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -29,7 +29,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -39,50 +39,34 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203114297'
+      - '1505398776671'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       X-Trello-Index-Last-Update:
-      - '66'
+      - '239'
       Content-Type:
       - application/json; charset=utf-8
+      Content-Length:
+      - '825'
       Etag:
-      - W/"SFWQj1E2s/62p4FKw4aqWw=="
+      - W/"339-12abfd90"
       Vary:
       - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '590'
       Date:
-      - Thu, 08 Dec 2016 13:18:34 GMT
+      - Thu, 14 Sep 2017 14:19:36 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=cf43b43703403bef5094bc1dab015bb91f97c95463bb357a2b882ed5c377c2ac; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:34 GMT; Secure
+      - dsc=948e3c31414031901627cb2b0de38f336a6156d959f7be62b1bee203b0d39a1c; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:36 GMT; Secure
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VTwW7bMAz9FUK7bEDaJNuapL41aTZk6LJsSW+9yBbjCJEp
-        g5IdtEX/fZSTou162MWAH8lH8j3qUVmjMnUxnhizLYajoZ6MRxeDr5MvYzMY
-        FaqnSFcoGRsMEdY1W4ow9ZqNhAyGQkILisikHeQJh61niKyLvaUSDp73YAki
-        6gqu3JbRnN/RHX3cJKCyIVhPGfzUewQbAXWwyB2F01wiYOKWrgEDRA/cEKxv
-        5msYfu5YdwhGRw2GbYsE+T0UTYi+Eg5CNOFOfTo/DXoteSqjxrmeKpwPKHtv
-        tQvYEwl+canJPugo0zwn1ZboVVLDTnbdxViHrN+PjM7588JX/by/fPg+y+e4
-        7EcR6Sx0Ip3lJ5HCznO8/X+xpNaM26CyR1Ujn6S5wRZTqXC2OqIktT6KsAIZ
-        G3TuMPUQpkqUklpVYZUjBwEttTZ2G73FA7rtD29lz8iNLFbInDPfpuAr5Ko8
-        dqktH/sW2iEZzd9E1zkdOz9rk4vbJfuG0i3VDdcuVbygi0qX+KzrP/A6EZv3
-        wY0VkvcNpmzLXSQMaSkZZ/+m0cw7zxL4MLkcDS7n3dg0xVWTO1u8rCeQOP7m
-        f3US+AVbJP1OwFNPOZ2jW8pj6BwqGVEUVMt0ZfD7SjrdJ1MPgt2Skfs7CBs7
-        S0kJz5rK7hV5yBEYW4uHzjlOq59YCA8gpsoFJ+fTPRyVzNQ11qK9OJyWdU2C
-        1tEW+/tkp3wz9QedvJ3Uy9nuvarugPfdOLXT3SmnYpFKsJW2nPx9evoLDMma
-        awEEAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:34 GMT
+      encoding: UTF-8
+      string: '{"id":"59b9327970bab79e44c2d3ba","name":"Sprint Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/7Zar7bNm/sprint-board","shortUrl":"https://trello.com/b/7Zar7bNm","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":true,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundBottomColor":"#0079BF","backgroundTopColor":"#0079BF","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"","orange":"","red":"","purple":"","blue":"","sky":"","lime":"","pink":"","black":""}}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:36 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/59b9327970bab79e44c2d3ba/lists?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -109,7 +93,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -119,34 +103,34 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203114648'
+      - '1505398777436'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '546'
+      - '795'
       Etag:
-      - W/"222-273e1966"
+      - W/"31b-dcae71d2"
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:18:34 GMT
+      - Thu, 14 Sep 2017 14:19:37 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=1d045b4cd59996af8a535db44cb468b17ccc4ba28c73212187c87256f181eb95; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:34 GMT; Secure
+      - dsc=555051a46268e75122d11cffd7c3c00b72397b729a5374e370fa3b754f91ea39; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:37 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
-        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
-        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:34 GMT
+      string: '[{"id":"59b9327abd286617989c5346","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":2048,"subscribed":false},{"id":"59b9327afca701a5af714cb4","name":"QA","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":4096,"subscribed":false},{"id":"59b932798dfe843857fe11b4","name":"Sprint
+        Backlog","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":8192,"subscribed":false},{"id":"59b9327970bab79e44c2d3bb","name":"To
+        Do","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":16384,"subscribed":false},{"id":"59b9327970bab79e44c2d3bc","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":32768,"subscribed":false},{"id":"59b9327970bab79e44c2d3bd","name":"Done","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:37 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/72tOJsGS?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +157,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -183,35 +167,34 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203114979'
+      - '1505398778250'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       X-Trello-Index-Last-Update:
-      - 'null'
+      - '103'
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '805'
+      - '829'
       Etag:
-      - W/"325-d20b3c91"
+      - W/"33d-25f949ca"
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:18:35 GMT
+      - Thu, 14 Sep 2017 14:19:38 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=771afddb91d769fa008da3a3b0947d9f005c0fd64f03943c9e7ea61a7d6da72f; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:34 GMT; Secure
+      - dsc=7e875359b02aed12cd24542357f29d85f30430ed726a05c2dee7bed624d859eb; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:38 GMT; Secure
     body:
       encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"Test Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/test-planning-board","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"sky","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#00AECC","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
-        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:35 GMT
+      string: '{"id":"59b9327bb2db28f633257d4d","name":"Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/72tOJsGS/planning-board","shortUrl":"https://trello.com/b/72tOJsGS","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":true,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundBottomColor":"#0079BF","backgroundTopColor":"#0079BF","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"","orange":"","red":"","purple":"","blue":"","sky":"","lime":"","pink":"","black":""}}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:38 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/lists/58495b6b4e0b95667e0bbb0d/cards?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/59b9327bb2db28f633257d4d/lists?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -238,7 +221,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -248,95 +231,33 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203115250'
+      - '1505398779026'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
+      Content-Length:
+      - '675'
       Etag:
-      - W/"CugRcx5UZikeHnGTQ51aXQ=="
+      - W/"2a3-8c25cc83"
       Vary:
       - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '2725'
       Date:
-      - Thu, 08 Dec 2016 13:18:35 GMT
+      - Thu, 14 Sep 2017 14:19:39 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=6b1b524e4ff554eef8cb96b4aedbcfa8227dea457b6cd38f0b1bb17c552a9a4f; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:35 GMT; Secure
+      - dsc=ded83da5c767ef1960e821fc2904c8baebd737c93e4f30bd22a7faf36ecd7cb5; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:38 GMT; Secure
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+2bC2/bOBLHvwrhxeGS3dDWW3KAxSGPNu1t2ubi5LrdtljQ
-        Em1zI0uqSMXNLnqf/WYoyVbcuLZxTp3gkgKpHxqKnPnzN0NSef9XS0St/ZYb
-        OF237/UdbvS7ruf58H+/b/qtvVY44uHVS8XHPcUUl639pIhj+DhOJQfTAYsl
-        32tF8N0pk+ogVOJaqBto0zJMj5oWNYIL0943uvum2e7azm/QZsRlCFccXDMR
-        s76IwWCfBD8FP/nwLyA/EzsgO5TYBvkbSVIh+T6xvN3K8JgpVvdCRIcpy/UI
-        /CCKBqHpmSzwPddwAtuPDC9s4UWnQqqFozQifc0rPu7zXP47VTis9x/xs94o
-        zcHQ8gJ8d6AUC0djnqij9JrndR/GLClYrD+aXTF1DNyc9XkMfnu/oI+B1YKb
-        JWzMoYu9LBeJIr67T/y2abUJJWYXX0AfsxRaMQ23a/jwnRNYju8EJnRNYjdP
-        RXIFDRz96b3+9W1sw/V9Fg0xYH+1rlMdOWOvdS34RCTDcrDVWKueyqIvw1z0
-        Gx8N0mG/GP4JzTaFULY0e3uEr9AKP03HOPzyEjZ1R/keo5eLTIk0ae2rvEDd
-        FLz2I7w8SsdZzBWvOvDlrg9v2YhI3zyG+Mo6aFUgy7dx7fxa6ItCsKKW6jAp
-        EV7doFPSOAUltPoxdGqvVUj0c2B/+VhF5TKP4duRUpnc73RUzuM4bYOTOmGn
-        Eak7XF8sN+yALqnUgqG+S32cbGYXfre+7H17Xgebn9d+Y15vcaJ2v9dEPUlZ
-        vE+ei8/kTcYT8GF4RUQiFYtjpgVez1c3CDzTbfuWZfumZVn+7fnaU4e9fnrw
-        /MHP168n3//bhG2Ear0JWxvChO3SIQiHDsRnmoJuJOqG3tLNsrlrbXzums2c
-        /MMP5CAMeaZYEnICY1Q8F+xD8iH5kbwSil0xIiTJiyQBWZI0IWrEScInZASh
-        mLAcbNJkIIZFroeDZsfpJFFizNEwTNM8Egn0LCIToUba/OjsJVGcjcuLwwIV
-        qK3RoshwHBF+d9RsGb8DL+uWGDYccW3/ukcmaX4lySDNdesRz+L0Bq6SNxJc
-        RlgSoW1U3ahs+iCOCcuVGLBQwfD4p0LkYIJtlPZ4KcHhZSBVUC+8jW8IKyuY
-        mOsrc57laVSE6JnZnbWlKB01KFSR6372Ds6wF0kK9xQ4hH5aqLo9XRGRdKBt
-        MpHxWCQcYwDReY1swNeHcYrTmBTg3JhMOETgmhOmR489aNwdWipj9yHZIpud
-        zbBZ39/3A4d7vj+IbI9BP6ywweYze5/suLvknJc+IFcJSHDqmBmwK0GDmPhn
-        0HnCYtChVLVSdkIWXxeyc83jYrxbE90yXaNrWW2r6zldp+vZ3m2i5xn/xe0W
-        Z/dLdO9hVmAL5GHx1gqoXxTZ9VBfzYvOMYc4RyijGfWzIoeRTLm/EvYb8VwP
-        +7UhYN+hmU1dmleCpFqQtBJkIxOMtSBpmtBakBQFSUtB0lKPVOtxaaIwN50o
-        At9eMVGcgotyINhTpthApjg5fwZuU2VXQVkcBlp65NXFJaIdeGSg32+nh62i
-        3toE6htA9+eAPkN4LbWlDBf5kM0Ybpme4wYLGT7qu6e/DNXkieENhhvfYvgK
-        IG04dT2Q1oYAUotmfhOkM3TGpRCWshN1sJSdzsaLbMNdkZ0HeVjIEoAlwwAu
-        KiV9KO2QHvASSVCCbJwVCpgKQCuBUI6x/C5ReRp3WDQGoCQaeVvkgb1hHgTA
-        A7MNRDgDkiJrmfbavFMQta/5RAEcGoTdGeTpuPJVgwi2FTiLq7r0nYx/C6JP
-        90sE+3ERgf2PRGg4dT0i1IZABJtmATWBCVkpBaqlQJmklRQoSoGCFGiipUBn
-        UqCohIoMS5lgb37hHazIhErDT+XU9sqperUN459fpN/NHhwtm1t5NpfkCSzs
-        Yw6ViUjAfItsdr/bsrwL1LZ2yfF8DVfJe1kJp/3cALYDq3BvIbCv/6n6L14c
-        dJ9KuJkcbPfxLsMb8VwvV9SGkCsgSXSpRb+qHavEsKR01PpbliaMwcaX3Z7X
-        SBMXADNENmBfA2cslCorxLCSh+adQD3ipuI1vgfqTuBmOW4jtgk2EUIYJRSV
-        cTrRcJXgMhWOCO5Oy/YWaWTcSaO6wfB2gx7m5I0e6/yHlP/ekgNyQZ6Rc3JK
-        XpLX8Kr6ZoYfz/VMYyF+zkcnlxdvg5MHd65jPp3D3uZDI1LrgaU2BLAYdEIZ
-        VZTTnMZUUADJ0nqSbRYUVtu0/BXrSSSA5DnMGF0+QeEYpkUueVuC49oRv6PS
-        5MkQ4AFNwEfQvSKq2sn1xUyRmEMP4Wquq52q5boRiXVWn0kRTo8z9Bo14eGU
-        XvN9WKUD50WCxWlpWVZxLCEvLi7OCFSEn2/IjuScVJOhKioVVG9yV9ee4B8p
-        7767mK6hY+hg/0b3QYLqyIlQL4o+GeYpFI4AYTDQZaHuVG1fVc1Vx752Z++y
-        94xgcglBUPO15gWImqtpHQ0j+QP8pCtKaD2X+6TWo0gGOWsnRdVv1GVp3DkW
-        MovZTXukxvE/RPSzCync+frYqNk+Drms67eYAHzzHk/wfbz/KpWqaUCpau9q
-        fX2tDSxU59U4ywuB2e06C/PCJ0tmz8qMfo95IVieF+yHU5a69ipl6eKIrpMx
-        LqEWzWfVUCN13CDaJ9PkYXbnAP7gKuKGlNZLXLVhB2YbzUyD2hTwRKdCpyh0
-        qJJ1QTwTOi2FviyvdTef11Z9QOFinqzINEg7JaBPOcsIbvFNU2B9VbkZoNPH
-        4Zvei299P4X6PLTf20YbqvWPUC7mkINEAmkF/5eyqDJTuZqIyGQkoNIesyvI
-        gXBFKokYsyEv17wDyE5tclgMcVMD4o8jGAjMQZBj62jipBdxzGbUB61MfoeP
-        2+FQIO5NwwQQBVvk+N2F/MY43oS1WZ8OYahnUYOQx3XIZ3juQguLD35OreNP
-        /1JHv2591+AB4dkJHyaeV0BkI5zrIbI2BEQagEhTnzmhvGgtL4Qjyos6Fl3+
-        xKW38c1jq7siFI+Q2uR5WiRRPn8kP9uDK2S9eYrbIhqiOG+ms6ncNsDtAb3/
-        m5a0UiOm5ndccy6LWEnceZ09jKQfcYO+tclL9Xf92BOB2h+qb5aL+IaMOQPL
-        8pgLuod7vcAIvdXb1pvLs+ajW/vUO+9nQ4jmd7BxdfJxp47vEBhc9HV8cXgd
-        nc0GpVs6E3ElOtpTtPIUfdl4Ko+eFKLMh703R9Tb3W1skJfrB1xLAYPxTXVG
-        fdvvTWdv9SjO/35ctkouV/u9R89vOWFKZNt0fG/xwVv2x83bw2hk3i+RnUe1
-        j+s4j5bIjXCuR+TasAMSBiJbQORqHzcc4MSc7uYuZbG7eRavWqB+i8UHb3sP
-        nMLnXELpC4MqJNarVZ/xSE/IsJCyebSYFf1YhOXaWG9Y72GXtLnUO86DnOMu
-        RAblMG4iwRojwhPBLZLR+35kxAdUnTkygi9nTLRN01l8thWkRaryo3t+POlx
-        MdF+vFVqI5zrMbE2BCZ6wESbOreZyCbLH2swNv+oU/Aw/hbo7p3ERUdJ7qaP
-        kn7HH9Ijz8gBOYTfx+T36mc2zR3ftRefIdmnl2fv3ON3D/4M6elvgxqhWm8K
-        14YwhU0qKaeM9uF31Pry8b/4kyjlnTsAAA==
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:35 GMT
+      encoding: UTF-8
+      string: '[{"id":"59b9327bc2d2d0f4d8473d92","name":"Ready for Estimation","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":4096,"subscribed":false},{"id":"59b9327b14df0bf32722d089","name":"Backlog","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":8192,"subscribed":false},{"id":"59b9327bb2db28f633257d4e","name":"To
+        Do","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":16384,"subscribed":false},{"id":"59b9327bb2db28f633257d4f","name":"Doing","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":32768,"subscribed":false},{"id":"59b9327bb2db28f633257d50","name":"Done","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:39 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb17/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/7Zar7bNm?card_checklists=all&cards=open&key=mykey&lists=open&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +284,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -373,1443 +294,37 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203115496'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:35 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=0d9ee40c7be25b943e9741999772fd97c4592ce68d6afc54b89642fc33501170; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:35 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:35 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb18/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203115755'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:35 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=f8830204ef6f1aaabde8b99f71099bf08ec23c88ccf62c410b912d3203b04b20; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:35 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:35 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb12/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203116038'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '125'
-      Etag:
-      - W/"7d-ea4c104c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:36 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=8049e0b5fe558a368d1034c31422b297d4e1476d0d865606cb53b2c263efc93e; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:36 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":3}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:36 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203116305'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '674'
-      Etag:
-      - W/"2a2-402ce24c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:36 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=a6930eecc63c663d5afe538c72a776e29c46a0ecc67bf2308deca4a9979ae9f4; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:36 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"57ab15db6568cc9735820ee3","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84863,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready for Estimation","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:36 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb12/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203116563'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '125'
-      Etag:
-      - W/"7d-ea4c104c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:36 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=6b7d69f4564e1d64e7b19a5a72a71c9ebe1219015a33dc6c276f0a84a7a1075a; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:36 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":3}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:36 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb12/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203116969'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"BCSI1EUOqbV1NorUSfTvrA=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:18:37 GMT
-      Content-Length:
-      - '814'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA41US3PbNhD+KxjkEnfMiBRN6nFT5EumSeqpkxwS+wACSwkj
-        EGBBQKrr8X/vLijZOsSTXCQA3O+xu1g8cq34klfzq0XV1M0V5M2iqusZ/jdN
-        MeWXvBFqAwNfPvK9C7TIL/lew0HbzSfoGvDf8Bg5WmEGuORDbAbpdXN21LpN
-        Ezf/oQzSyS3I3YcAHTLV59s1rQiF/NJ1HdgwiokQhNy+7BWQQB+0s3wZfEQF
-        FYEvbTQmLdeu6w0EOBp4OlO5DSLl8OMeD40bzlwq/PJRDGElg97r8IB2p3lR
-        Z8U0y+dfinJZzJdl/W6Rz77z0QRGvHnDVlJCH4SVwNBWAK/Fnb2zf7BPOoid
-        YHpgPlqL5WLOsrAFZuHAtsKrg/CIcbbVm+gF5UOwa3ewQXdAQOmcV9qiM8UO
-        OmwTfH3zgQUQ3RgsI1UmoQkRe8pD0bf1OTN9Cx4SkyBiBQn/+ZYdnN8NrHU+
-        sSvojXvAqOFhwIIxYRVh1VFopF4Zw4QPuhUyYHrwT9QeIcQx4imUUXo9+EEj
-        kQ3mgYm90EY0BlKkh947FSVV5kU5IfVYqDaG6JPP29UNubAONTWl0LgYTnza
-        YLuYaxOm1z0YbYF6gN35THeW1u+No+vFIhbXsANgB/bARMqeHJypI9PYuzt7
-        7PS1COLsgr1+1y45dOjpFKDVe4eNpgGbzZoaashzVZRFKeq5wp9ccApKV99g
-        mehmvjKLU+D3FPtRNGBe4pSQ8yuoZ7NWlbVoFqqqjnFIl3TnkJeyLfKroiqb
-        vM6lnM4alXTH+T2Og1a3W+cRUywK2q2ex27t9uBPKXXCRmHS0UvEc/bm5O7x
-        7F35mcffrI0VHZaWH5s3uYYerCJBeiOMQ1e8jx47gAdxoMkunu6fYTflkr2t
-        LtjfMHaX7SwO13PL/0IyfBDk7jSqOCbwL06wFQYnbAinGXgrhdnHYbIHE7sL
-        lOodKk2ni3KGT9hAZfvqsel8G0I/LCcTnDRj3Dt8xiZy4nv4s1rEG7L466gJ
-        lj/ry6zK/NF1llxnR9eZQ9cDuc665DpzNju5zsh1NrrORtNZMs2f/geSQ5cc
-        6QUAAA==
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:37 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb11/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203117241'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:37 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=dc262ec11b72e8465f6a11e79f296cc295e930758b15d36ffad27ab8eb995028; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:37 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:37 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb11/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203117501'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:37 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=85fb89df34876f8563f3d9c731374016c3b7367f71c9db0af8501eedcbc375f3; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:37 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:37 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb11/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203117872'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"JSDih8nnIM2H58WPF1NGKA=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:18:37 GMT
-      Content-Length:
-      - '721'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VTy27bMBD8FYK5JIUVS7YlObq5TlEEddIgjx7a5MDHyiZC
-        kSpF2XWD/HuXku34EvQi8bEzO7ucfaVK0oKm08lFyjM+gZhfpFmW45/zJKED
-        yplcQkOLV7q2PiziAV0r2CizvIaKg/uBx8hRMt3AgDYtb4RT/OiotEveLv9i
-        GqQTKxAvVx4qZMqOt/OwCijkF7aqwPg+GfOeidX7XkJIUHtlDS28azGDbIEW
-        ptW6W85tVWvwsBPwdpTl3rOuhl/PeKhtc6RS4s2CNX4mvForv0W5ozjJomQU
-        xdOHZFwk02Kcn0+T7CftRWDEyQmZCQG1Z0YAQVkenGJP5sl8IgtsgvNbohri
-        WmOwX8Qa4ldADGzIijm5YQ5B1pRq2ToWCgq4S7sxXlUQgMJaJ5VBaZJslF91
-        8PntFfHAqj5YtKE1HTog2joUIsPd/Jg53HkHHRMLxBI6/M092Vj30pDSuo5d
-        Qq3tFqOabYMdI8zIgJW7RD31TGvCnFclEx7Lg9+tcggJHD0+hJJQXg2uUUhk
-        vN4StmZKM66hi3RQOytbETrznrlDqr5RZetb1+n8evcF2+Z7qWgPwEL7jlw/
-        PBJbkiSN49D3J4NvchOc2u92b3XJPDuyyMduGVCoUOQ+QMnPFl8qjEie8wwy
-        iGOZjJMxy6YSPzGjIagzr8Y6g7c+mKZRTJ9D7IJx0DsP4g5BHfsU4rEok3iS
-        pGMeZ7EQo5zLjr2fswPkfmUdYpKLUdjNDuMxt2twe+EVMy3T3dF7xKFGfaTB
-        sAqLp7d5QU7TM3IH/TuQ7zUYnBfxcnAyugj+oMMN02jAxu8tciqYXrfNcK3c
-        kp2h5Noi92iS5hnOaxPkPjpsKV15XzfFcIhG1Nqe4zsOxXDF08W3pd8grv1/
-        1BDLjuo8SiO3ExpZFNoEoZHuhUbWRHuhURAa9UKjXmfU6aRv/wA5ss0P/AQA
-        AA==
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:37 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb14/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203118154'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:38 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=febbd590acaee175b239193ad2642308f0967242ed2cb6a3faf81e77b9ecbebb; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:38 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:38 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb14/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203118473'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '2'
-      Etag:
-      - W/"2-d4cbb29"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:38 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=7e2976a7e82e5b7e4c6043b3a89e35a1458c25c2bde58d77cfab811198e34b98; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:38 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:38 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb14/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203118803'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '980'
-      Etag:
-      - W/"3d4-18278155"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:38 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"id":"58495b6b4e0b95667e0bbb14","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":3,"checkItemsChecked":0,"comments":0,"attachments":0,"description":true,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T13:18:38.744Z","desc":"##
-        Acceptance criteria\n\n* Arcus is configured to be able to work as compute
-        node with calvus as control/admin node\n","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":["58495b6b4e0b95667e0bbb2a"],"idLabels":[],"idList":"578e03cf104153b060cc27bd","idMembers":[],"idShort":193,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[],"name":"P8:
-        (1.5) Prepare arcus as compute node for Newton deployment (from calvus)","pos":262144,"shortUrl":"https://trello.com/c/oYslZ8dq","url":"https://trello.com/c/oYslZ8dq/193-p8-1-5-prepare-arcus-as-compute-node-for-newton-deployment-from-calvus"}'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:38 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb13/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203119050'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '125'
-      Etag:
-      - W/"7d-eb8e7a7b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=8e13b749b17b671c237d395abd441c59cd9fc294377e8bd6577a6b810dcde80b; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":2}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb13/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203119281'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '125'
-      Etag:
-      - W/"7d-eb8e7a7b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=42e1c2ec6d55469be0c0c06bd03f45fe81de7ecf651aeeb2e1e1ba5870e85c3c; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":2}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:39 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb13/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203119659'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"kE0T0/5BpqQP0G60sQoNeQ=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:18:39 GMT
-      Content-Length:
-      - '820'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA41UTW/bOBD9KwR7aRdRLVmW/HFznWLbRZstmraHbXKgyJFN
-        hCK1FGlvNsh/3xnKTnzYogUEmx/zZt68meED14qveLWYLaumbmaQN8uqruf4
-        3zRFyS94I9QWBr564HsXaJFf8L2Gg7bbj9A14L/hMfpohRnggg+xGaTXzdlR
-        67ZN3P6LYdCd3IG8ex+gQ0/1+XZDK0Khf+m6DmwYg4kQhNw97xVQgD5oZ/kq
-        +IgRVAS+stGYtNy4rjcQ4Ejg8SzKdRAph++3eGjccMZS4c0HMYS1DHqvwz3S
-        neZFnRXTLF98KcpVsViVy9fVIv+LjyTQ4sULtpYS+iCsBIa0AngtbuyN/Y1d
-        wSE4y/TAfLQW5WK4CztgFg5sJ7w6CI8YZ1u9jV5QPgS7dAcbdAcElM55pS0y
-        U+ygwy7BN5/eswCiG41lJGUSmhCxpzwU3W3OPdNd8JA8CXKsIOGvrtnB+buB
-        tc4n7wp64+7RargfUDAmrCKsOgYaXa+NYcIH3QoZMD34O2qPEPIx4smUUXo9
-        +EGjIxvMPRN7oY1oDCRLD713KkpS5jlyQupRqDaG6BPP3z+/RdnCSBW7AzDR
-        UZGPX74y17KiynOS/cZiSa6oUWn9xjjqKRL+GFsbLC0BhJdxGKXo+hiwKihJ
-        ylawO4s1SLoQtzNe6KfXBuIw0Rbhxz64FEGctd+PO/GCQ4csTgZavXHYBjR+
-        83lTQw15roqyKEW9UPiTC05GaTAMikh9+4NJLSt+S7YfRAPm2U4JuZhBPZ+3
-        qqxFs1TVyQ7dpbgLyEvZFvmsqMomr3Mpp/NGpbjjdB+HRavrnfOIKZYz2q2f
-        hnLj9uBPKXXCRmHS0bPFU/bmxO7h7NX5P46/qI0VHUrLj1WeXEIPVlFAekGM
-        Q1a8jx4rgAdxoLmfPt4+wT4tV+zl9BW7TPVlfyIYnwd5dxpc/OAfnGcrDM7b
-        EE4T8VIKs8cWSB30Cl33jjzPF9V0ge8fyfTVY5H5LoR+WE0mOHfGuNfYaBM5
-        2f8Rmnfv1kui9HOrCcqd9ctsmo1dmDlkORDLzCaWGX4nlhmxzEaW2UgySyT5
-        43/TM1Lx5wUAAA==
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb0f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203119920'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=aa5769e56e40bfff8fddefa442fc51d348712f09cb6d6dc44dde8028e448522b; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb1a/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203120223'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '248'
-      Etag:
-      - W/"f8-932b23b9"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:40 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=df7575f8a2b0d0bc4a0e85da227c65e719bef00d1b54abc093205d9fe4b06a44; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:40 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":19},{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":1}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:40 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb1a/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203120498'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '248'
-      Etag:
-      - W/"f8-932b23b9"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:40 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=5ea9e292d27918dbc86f2807be01ffae82cc8d3a4ec59a3dc032b538b52727af; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:40 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":19},{"id":"58495b7784e677fd36ab952c","idBoard":"578ddfc161a876504837d06c","name":"Blocked/Dependent","color":"purple","uses":1}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:40 GMT
-- request:
-    method: delete
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb1a/idLabels/578ddfc161a876504837d07d?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203120839'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '16'
-      Etag:
-      - W/"10-3393249b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:40 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"_value":null}
-
-'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:40 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb1a/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203121313'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"pMfKYeTI5Szu5eQPSl2pGw=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:18:41 GMT
-      Content-Length:
-      - '788'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA41UW2/TMBT+K5Z5AdS0SdOkbSSExoYAaSDECg/AHnw5bQ2O
-        HXzZGNP+O8dpuhVtCF4Sx/nOd75zvaZK0oZWi9my4jWfQc6XVV3P8c15weiI
-        ciY34GlzTS9sSId8RC8UXCqzeQstB/cJr5FjzbSHEfWRe+EUP7ha2w2Pm1/o
-        BunEFsT3NwFaZFocfh6nU7JCfmHbFkxASDmiLAQmtsM3/pSQHHRBWUOb4CJ6
-        kBFoY6LW/fHYtp2GAIOAmwMvZ4H1MXw5x0tt/YFKiX9OmQ9HIqgLFa5Q7jQv
-        6qyYZvliVZRNsWhmxXha1J/pTgQiHj0iR0JAF5gRQFBWAKfYV/PVPCWrLRAP
-        7gIcWVtHhDXCRudh7CM+JBDliYvGYCKJNSQgHMxGGUAKvEJ5UQ48rgezQDSg
-        QkQDubTu+8C8J/G2BcKZV4J0qgONVD65NSCwQiTYBzT8j4AP0ZDjvSW5VGFL
-        mCGvV6v3pHP25xV57AGD39WsVyQhMKX9k2Sd8uP9w95Vry84qzUK5Fe9Bs8w
-        jFcqvI6cbJyNHWGeoIFMIntRe/tEfyfsfjrPPp69JB7LLkDrVBQs17vUxOm8
-        UthuO7kJi5F8wzxhZDI5c74h2xA630wmyqwdG5s46MZAJzvjyYnynWZX421o
-        9XMln1XLajpL5C+0Tc1MoglK/8GfQnaAvSbHQxudsMAOuvfvjTyi0GJa9wAl
-        X1jm+umdz3kNNeS5LMqiZPVC4iNP06tkP1da+TQ9X/4y6FVJzxP2lHHQdzjJ
-        xGIG9Xy+lmXN+FJW1YBDut7vAvJSrIt8VlQlz+tciOmcy97vbjkMs6bk2dY6
-        tCmWVfo6up3pY4sDsg+pZSYy3V/dIW6j13t11wdL6yGN/5kbg42GiKFWkxPo
-        wMjkMC0gbVEV7aLDCuAFFj5to5vzW7P3Rd6Qx+WTfjzutza24L1hQp7OIs10
-        OVsWU9yVKScfHVaU7nstOGxV2/eYmPyY+u5l3e+b+G/UBHObdUWelRnOQXYr
-        KUuSMgmZNdmBpGwn6eY3EY9KVgIGAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:41 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203121604'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '124'
-      Etag:
-      - W/"7c-1a0c1e2b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:18:41 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=50ebf6332bf001205962ae8f9af36e4284d4370a7d8c3aff68fdc3840bd9f919; Path=/;
-        Expires=Sun, 11 Dec 2016 13:18:41 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":18}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:18:41 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/NzGCbEeN?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203177578'
+      - '1505398780109'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       X-Trello-Index-Last-Update:
-      - '82'
+      - '239'
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"SFWQj1E2s/62p4FKw4aqWw=="
+      - W/"L8q3BqjmZz3pf3y6IqtpKA=="
       Vary:
       - Accept-Encoding
       Content-Encoding:
       - gzip
       Content-Length:
-      - '590'
+      - '1668'
       Date:
-      - Thu, 08 Dec 2016 13:19:37 GMT
+      - Thu, 14 Sep 2017 14:19:40 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=fc46891c8dfc9e69125549fd0d441ae5fbf4e4645ca6282dfcc7cbb4cf6219fc; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:37 GMT; Secure
+      - dsc=e19b3805b8c76f1658b59bb99659b8ffa3a99287c44373c750782fbf19e4a825; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:39 GMT; Secure
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4VTwW7bMAz9FUK7bEDaJNuapL41aTZk6LJsSW+9yBbjCJEp
-        g5IdtEX/fZSTou162MWAH8lH8j3qUVmjMnUxnhizLYajoZ6MRxeDr5MvYzMY
-        FaqnSFcoGRsMEdY1W4ow9ZqNhAyGQkILisikHeQJh61niKyLvaUSDp73YAki
-        6gqu3JbRnN/RHX3cJKCyIVhPGfzUewQbAXWwyB2F01wiYOKWrgEDRA/cEKxv
-        5msYfu5YdwhGRw2GbYsE+T0UTYi+Eg5CNOFOfTo/DXoteSqjxrmeKpwPKHtv
-        tQvYEwl+canJPugo0zwn1ZboVVLDTnbdxViHrN+PjM7588JX/by/fPg+y+e4
-        7EcR6Sx0Ip3lJ5HCznO8/X+xpNaM26CyR1Ujn6S5wRZTqXC2OqIktT6KsAIZ
-        G3TuMPUQpkqUklpVYZUjBwEttTZ2G73FA7rtD29lz8iNLFbInDPfpuAr5Ko8
-        dqktH/sW2iEZzd9E1zkdOz9rk4vbJfuG0i3VDdcuVbygi0qX+KzrP/A6EZv3
-        wY0VkvcNpmzLXSQMaSkZZ/+m0cw7zxL4MLkcDS7n3dg0xVWTO1u8rCeQOP7m
-        f3US+AVbJP1OwFNPOZ2jW8pj6BwqGVEUVMt0ZfD7SjrdJ1MPgt2Skfs7CBs7
-        S0kJz5rK7hV5yBEYW4uHzjlOq59YCA8gpsoFJ+fTPRyVzNQ11qK9OJyWdU2C
-        1tEW+/tkp3wz9QedvJ3Uy9nuvarugPfdOLXT3SmnYpFKsJW2nPx9evoLDMma
-        awEEAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:37 GMT
+        H4sIAAAAAAAAA+2bW3PaOBSA/0qHfQ1YV0vKW0iTNm2aJk3abtvpg2QL4omxWduQJhn++0q+gKHZYLYMw4OfIh3rSEfn8gUL8dQJ/M5hhwolMGKCASUVE5oQD/lYyc5BJ5IjbUZcj5Mgyl71Y5n4Rurr1DPSsvVaZrJzGE3C8KDjhXGqzZwDGab6wEz/MRnKKHiUWRBH1aBxEEW1QZMkNJPdZtk4PXScLNFhGPe8eOQoh32XCVMXIyfNDeiq0oD0Nk6yz+v1zNBxogdp5/CpM9bJKEhTY8e5nmqrauacykybQdM4C6KhEflBKlWo7RpmppGOMqPbGemR0klqhEE0DbJ8M8vyVIeDd3FgtpglE7Mnz9h5HE/tw5rkaFiskujhJJSJXUSGOvJlcqq1fxIVS1d+UdK7GybxJLIxUuHEGrqQnY3kUFceXRFf22n93x/eBKF+Zvp+Egxvs0indk/GmLulhfpxlsWj4ziME/P4LwCY6J8ujbiJxy89/v2ZJ6O+vpyoMPAW7jEikyxL/csyQAvZmfV/KZgddEKpdHhhcjSP8DDROiry8sEmw33RjhMZWVfZdmLdYhvjSTIOS2Hu27yV3j0UjTAYlSKTrHfVMLMl25wV0TRr/niaV5DkPlCez5EinGrflRQyavd6q727s0yPrk3eWDt//PytTHzz5Fym2ZGXBWZ/1gYEIOsC0YXkBpJDIA4B7HEqvr9YfYFfVOiLJR3450Ga1cZwf6A5wZyygYZQkXzMhyK1v8SZtdPaHPjXtuo6h5DazlGWSe/WVkie55UJxnFBlkdDzgdU5Xec2/bUSY0nJjbXYptpZckdmZkFBQede5lEeQeA2az0X2gsbjwLYXQxC6H5LGkWeHd5NTabw2WLKVw8s1MYv9lsKyM4ktFEhvnWF56YB7TEJoI2gWKj4lKKacmt8yKjruSbkz7gcV4r/rBIYQMi2zBuqLmv/3DzMNb2cQE52ypIaAd6RcOaOA30vSFMEbsydKVF6USlXhKommgQD9Vk+Fik0jxNi9UX3WPb0uVScyQuG5j3bTImwbgAfZXYkzmiTPM4HpmayyoEzZ4TLukE/nEt+kUSlolZdMNaRF7+n+A5NX8/44z//Ce0UHQg7eYR9ZaMmh2sQIBjBKgeEKEZwYCzrUGAH1LeE4zuBQTcFgINIYAqCEAMAYPLFDg+C66u375BLQV2Q4GavzejQKXoQLebh3QNBSAV3B1I4msGfM70Nj8KuD1M0V5QgLUUaEgBPKeAcF3AlilwefYQ48S7aymwGwrU/L0ZBSpFx5RkHtKXKeBxRQgSkniMYakB2CIFIOwRsh+fBXhLgYYUIBUFkIsgwcsUeNSn6NPpyXVLgd1QoObvzShQKTqQd/OQvkwB7VKPeeaVQEBOfSG9bVIA90zB7gMFEGop0JACtKKA8bPLxDIFpu/pN60maUuB3VCg5u/NKFApOgh1EV1LAR8gIZjyXJ8q1/cX7xDboADtcY73gQJQtBRoSAF3TgHjabhyOng7ubrAX/yTlgK7oUDN35tRoFJ0oOjmIV1LATxgEDJMXOIKtM2vCCDrMQ72gQIItBRoSAFWUYBQzujK6eDJPw/Hb9HH85YCu6FAzd+bUaBSdBDoIraeAlwNOKFEeJAC5LpimxQQPcb2440AthRoSAFeUYAigvjK6eD9pyt4GqWipcBuKFDz92YUqBQdBLt5SNecC9CBUsgnyvwBktBtfkeAUI+ivXgjQLilQEMKiDkFuOBo5XTw1wXpX3+FsKXAbihQ8/dmFKgUHYS7SKylwEC5eKARRtJ8KtCQbvNcALk9IPbim0JEWgo0owAGS5eGVk4Hry+/fZlOwU1Lgd1QoObvzShQKTqIdDFYRwEIiRaMEUYUFdp0t3kugHhPcLYXFGivDjalwPzqIEOAi5XTQdH/O/r89dfHlgK7oUDN35tRoFJ0EO3itXcHIfSg5yoIkMK+T/AAb5ECGPag2A8KtHcHm1JgfneQcZfgldPBd49x/OH9fb+lwG4oUPP3ZhSoFB3kdvEzdwetHWVnwQNbWlL5iLsuNDUmPIqJ/X6hTI3Xsf0tyTO/uGlQwcUNFED4MxupIyk3YeBJBqCkcsAg8fLqLk24OvqT9QkQboP1n6PLyq+SpPFl/Ee+4FCgJras6KuFLTfxq9fxn5gAXczJ/7DB22JK2OsITXJidQK/bkOk/ygrhHkDfs6En7N/AUB07TOuNgAA
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:40 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/lists/59b932798dfe843857fe11b4/cards?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -1836,7 +351,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -1846,34 +361,791 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203177860'
+      - '1505398780888'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"Ty9zH7bMgCJEmxpN9SNTlA=="
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1196'
+      Date:
+      - Thu, 14 Sep 2017 14:19:40 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=35d24cf0658193d83d8394e6f171299b267446eff0b68745b93ed4c96e797b5c; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:40 GMT; Secure
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+3aW3ObOBQA4P/CcwDdL36LvUmbbXpJnabb7fRBApEwwcZrsNMk4/9eYRsHk8wszHg8PPAUBDqyOEff2Cj8fHbi0Bk4VGolQqCDUCBNBDUhUxRy6pw4wZ0J7i9yMxnnKjeZM5guksSeTtLM2NBIJZk5cUJ77VJl+WmQx8s4f7RjIgC5C6QLyTUkAyAHAHqCyn/tmKHJAttje/SXylU5bBwOUzXfTklixCUHWmkuDSEBCrFWTtHpMs7ySh8RRkYQLCiPDISarPt8NBNt5tlNmhfz/PmrODe+S+c2ENKicZrnKribmGk+SpdmXk4hiSdxbu/z2VG7DuvmzMxH67k9O5nNxcKedNL74ibiTOnEnNqRJQUnzoOaT9cNAFarbQYTO+PGoxBOX0YhdD1KlsfBvb2fpmMw/jIEw6tiCJs3pU2SbbIxUdOFSta3/pKJXUGnamKKIkI76iy1IYxSbGeVFRm8jKf39uKVenc2BCK1XbQKb816bst0vUpsGirpGz5eP85McTmfmyRJiyO9KbTtGGwOiikuY/MQT283tduWbjujbKGzYB7ryqkovdWL26fNUtot1M2nvzRHxZHZflQ62dZzf4LrdrEY5/Esj9Ppy8JemHJh2MNROpklJjfby6u3Tu7FxOGoUv3NItwuzE0zqVRkndtv88Tez12ez7KB72/S5dlp+4FfyfcbyVj8f6APqWsrujqpsRcYAWoiIg0nGAh+QPZiQIUnOe0Ee9azb8gelewhhoDDffeji/hq/P4d6t0fx30l3+3cl4E+ZK4t6Sv3kErBIkVCw0EouDns1z3zMEWdcM979w3d4517yRjg++6/XDymeB7c9+6P476S73buy0DfkrQlrbsPhCYESUUCzrEyABzUPYQeId34vhe9+4buSekeMQQJ3nf/ZM7R1/Ozce/+OO4r+W7nvgz0oXBtSevuDaMBD+wPfQkFDaUKDusee5ZoF9wj1Ltv6J6W7m2eGZf77pcf6A+j7cf37o/ivpLvdu7LQB8h15a07j4ESEquAxZSzcJw/XB3QPfUEwJ3wT2UvfuG7tnOvc00rO3r3S2uPuGb8Kx3fxz3lXy3c18G+lC6tqRvuMcRh5BjwgiT6LDb+ZB7XIAuuEegd9/QPS/dEyo4re3rnf33OHqPPl/27o/jvpLvdu7LQB8B15b0lXuhI0EokQGkADEmD+teepx343c+7N03dC9K9xQRJGr7eg9fr+D5NJO9++O4r+S7nfsy0EfQtSV99XxPI61RSLT9AxShh93PR8ijqBO/8xHu3Td0L3fuhRSotq/3+xMZjr9D2Ls/jvtKvtu5LwN9hF1b0rr7SDMcGYSRst/8BtLDPt8j5gHZif/jIdK7b+Yeg73Xdmr7euMvP26WS3Dduz+O+0q+27kvA31EXFvSmnsIiZGcE040lcY2D/t8j4QnBe+E+/51vabud6/rcQSErO3ryeE/02/ff3/u3R/HfSXf7dyXgT6iLn71vh6EAQyYhgBpHIYER/ig7jH0oOyG+/59vabud+/rccEIru3r/f2Uph8/PAx798dxX8l3O/dloI+Ya0u6+vUH57nRRaAvAAA=
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:41 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0bcd82b485ed6a5175/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398781872'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '546'
+      - '746'
       Etag:
-      - W/"222-273e1966"
+      - W/"2ea-e4203003"
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:37 GMT
+      - Thu, 14 Sep 2017 14:19:41 GMT
       Connection:
       - keep-alive
-      Set-Cookie:
-      - dsc=c32e6df82b732af57094ef524055061ee19d01768c3e4b6f44e27a89995fc804; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:37 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
-        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
-        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:37 GMT
+      string: '{"id":"59ba8d0bcd82b485ed6a5175","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:41.767Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":15,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"21","pos":245760,"shortUrl":"https://trello.com/c/QaGEB08o","url":"https://trello.com/c/QaGEB08o/15-21"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:41 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0b83205ef49e743087/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398782882'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-4fa20426"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:42 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0b83205ef49e743087","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:42.734Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":16,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"22","pos":262144,"shortUrl":"https://trello.com/c/CIiQSHG2","url":"https://trello.com/c/CIiQSHG2/16-22"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:43 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0b15986fa4de70d87e/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398783829'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-7c80769"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:43 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0b15986fa4de70d87e","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:43.708Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":17,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"23","pos":278528,"shortUrl":"https://trello.com/c/PIyo3rck","url":"https://trello.com/c/PIyo3rck/17-23"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:43 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0c8b4429a4c773ae00/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398784760'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-279cd3a8"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:44 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0c8b4429a4c773ae00","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:44.666Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":18,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"24","pos":294912,"shortUrl":"https://trello.com/c/zeF2RFES","url":"https://trello.com/c/zeF2RFES/18-24"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:44 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0e65c7c5ef9185d9ac/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398786657'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-ab73f434"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:46 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0e65c7c5ef9185d9ac","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:45.649Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":19,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"25","pos":311296,"shortUrl":"https://trello.com/c/vK5Yebus","url":"https://trello.com/c/vK5Yebus/19-25"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:46 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0d02997bc6d5b6dd22/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398787611'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-1150325b"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:47 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0d02997bc6d5b6dd22","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:47.510Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":20,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"26","pos":327680,"shortUrl":"https://trello.com/c/huQN3VdE","url":"https://trello.com/c/huQN3VdE/20-26"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:47 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0d023f711734646925/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398788574'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-15f4b410"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:48 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0d023f711734646925","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:48.465Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":21,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"27","pos":344064,"shortUrl":"https://trello.com/c/EqyCH2OL","url":"https://trello.com/c/EqyCH2OL/21-27"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:48 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0d8bf84549c1502669/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398789474'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-acb0177a"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:49 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0d8bf84549c1502669","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:49.382Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":22,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"28","pos":360448,"shortUrl":"https://trello.com/c/wRQ1Fns9","url":"https://trello.com/c/wRQ1Fns9/22-28"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:49 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0e5fbb2d4bfbb0a45e/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398790428'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-2f821cf6"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:50 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0e5fbb2d4bfbb0a45e","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:50.315Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":23,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"29","pos":376832,"shortUrl":"https://trello.com/c/xN4BSW11","url":"https://trello.com/c/xN4BSW11/23-29"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:50 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d0fb63fe232ad8be152/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398791422'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-95bd2c15"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:51 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d0fb63fe232ad8be152","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:51.300Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":24,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"30","pos":393216,"shortUrl":"https://trello.com/c/SPYVvv0T","url":"https://trello.com/c/SPYVvv0T/24-30"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:51 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d114e977474b59ed115/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398792368'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-8949b758"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:52 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d114e977474b59ed115","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:52.274Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":25,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"31","pos":409600,"shortUrl":"https://trello.com/c/9BXnUWxO","url":"https://trello.com/c/9BXnUWxO/25-31"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:52 GMT
+- request:
+    method: put
+    uri: https://api.trello.com/1/cards/59ba8d11c1c6b102b3dd43f3/idBoard?key=mykey&token=mytoken
+    body:
+      encoding: UTF-8
+      string: value=59b9327bb2db28f633257d4d&idList=59b9327bc2d2d0f4d8473d92
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398793359'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '746'
+      Etag:
+      - W/"2ea-1c957a90"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:53 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"59ba8d11c1c6b102b3dd43f3","badges":{"votes":0,"attachmentsByType":{"trello":{"board":0,"card":0}},"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":0,"checkItemsChecked":0,"comments":0,"attachments":0,"description":false,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2017-09-14T14:19:53.253Z","desc":"","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"59b9327bb2db28f633257d4d","idChecklists":[],"idLabels":[],"idList":"59b9327bc2d2d0f4d8473d92","idMembers":[],"idShort":26,"idAttachmentCover":null,"labels":[],"manualCoverAttachment":false,"name":"32","pos":425984,"shortUrl":"https://trello.com/c/JzooMKwB","url":"https://trello.com/c/JzooMKwB/26-32"}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:53 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/neUHHzDo?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/59b9327970bab79e44c2d3ba/lists?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -1900,7 +1172,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -1910,35 +1182,286 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203178208'
+      - '1505398794153'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '795'
+      Etag:
+      - W/"31b-dcae71d2"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:54 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=6aa2c2c50bbd1ad1d61eed4bd68ee090990d0720d67c9d53046ea1e75d12c579; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:54 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"59b9327abd286617989c5346","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":2048,"subscribed":false},{"id":"59b9327afca701a5af714cb4","name":"QA","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":4096,"subscribed":false},{"id":"59b932798dfe843857fe11b4","name":"Sprint
+        Backlog","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":8192,"subscribed":false},{"id":"59b9327970bab79e44c2d3bb","name":"To
+        Do","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":16384,"subscribed":false},{"id":"59b9327970bab79e44c2d3bc","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":32768,"subscribed":false},{"id":"59b9327970bab79e44c2d3bd","name":"Done","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:54 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/lists/59b9327abd286617989c5346/cards?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398794904'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:54 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=8c8cb7b75b509892bd8a0b869f98ef4808f6085795a998388b7060f63544147d; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:54 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:55 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/59b9327970bab79e44c2d3ba/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398795676'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '795'
+      Etag:
+      - W/"31b-dcae71d2"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:55 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=26f9c6e365b9a5552df57ecb70f9ec3e61d49bff811f7d157def0f20e67c77a7; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:55 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"59b9327abd286617989c5346","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":2048,"subscribed":false},{"id":"59b9327afca701a5af714cb4","name":"QA","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":4096,"subscribed":false},{"id":"59b932798dfe843857fe11b4","name":"Sprint
+        Backlog","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":8192,"subscribed":false},{"id":"59b9327970bab79e44c2d3bb","name":"To
+        Do","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":16384,"subscribed":false},{"id":"59b9327970bab79e44c2d3bc","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":32768,"subscribed":false},{"id":"59b9327970bab79e44c2d3bd","name":"Done","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:55 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/lists/59b9327afca701a5af714cb4/cards?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398796531'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Etag:
+      - W/"2-d4cbb29"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:56 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=d47b290be7a6378eb158284d1671629c0311f5d90ed124339a34d95f2aaf679a; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:56 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:56 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/7Zar7bNm?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398797379'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       X-Trello-Index-Last-Update:
-      - '20'
+      - '287'
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '805'
+      - '825'
       Etag:
-      - W/"325-d20b3c91"
+      - W/"339-12abfd90"
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:38 GMT
+      - Thu, 14 Sep 2017 14:19:57 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=923a24de450e0317cf09f35d5c69abedd7ffba2f23d4a05f9846b4c3fb66b0c2; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:38 GMT; Secure
+      - dsc=01b29e3092f78ca76a8a9e433721e577b3896f09f81b8c3e9588578c30e23e28; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:57 GMT; Secure
     body:
       encoding: UTF-8
-      string: '{"id":"577b6e6e00d1313a68d3a60a","name":"Test Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/neUHHzDo/test-planning-board","shortUrl":"https://trello.com/b/neUHHzDo","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":false,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"sky","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundColor":"#00AECC","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"Under
-        waterline","orange":"","red":"","purple":"Dependent","blue":"","sky":"","lime":"","pink":"","black":"Pairing"}}'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:38 GMT
+      string: '{"id":"59b9327970bab79e44c2d3ba","name":"Sprint Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/7Zar7bNm/sprint-board","shortUrl":"https://trello.com/b/7Zar7bNm","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":true,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundBottomColor":"#0079BF","backgroundTopColor":"#0079BF","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"","orange":"","red":"","purple":"","blue":"","sky":"","lime":"","pink":"","black":""}}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:57 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/lists/58495b6b4e0b95667e0bbb0d/cards?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/59b9327970bab79e44c2d3ba/lists?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -1965,7 +1488,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -1975,70 +1498,228 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203178479'
+      - '1505398798161'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
+      Content-Length:
+      - '795'
       Etag:
-      - W/"lyihBA8kZ4eD2Dl2QPL9CA=="
+      - W/"31b-dcae71d2"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:58 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=b120aabb0e8aecce91756dc95ce2b5f555e3a1b6478f18ec364071c67651a9a7; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:58 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"59b9327abd286617989c5346","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":2048,"subscribed":false},{"id":"59b9327afca701a5af714cb4","name":"QA","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":4096,"subscribed":false},{"id":"59b932798dfe843857fe11b4","name":"Sprint
+        Backlog","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":8192,"subscribed":false},{"id":"59b9327970bab79e44c2d3bb","name":"To
+        Do","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":16384,"subscribed":false},{"id":"59b9327970bab79e44c2d3bc","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":32768,"subscribed":false},{"id":"59b9327970bab79e44c2d3bd","name":"Done","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:58 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/72tOJsGS?key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398798922'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      X-Trello-Index-Last-Update:
+      - '164'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '829'
+      Etag:
+      - W/"33d-25f949ca"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:58 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=cf4106c7dcbe25b56209d3f8718843aa79c0c7fba3917455292a903b629c767a; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:58 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '{"id":"59b9327bb2db28f633257d4d","name":"Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/72tOJsGS/planning-board","shortUrl":"https://trello.com/b/72tOJsGS","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":true,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundBottomColor":"#0079BF","backgroundTopColor":"#0079BF","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"","orange":"","red":"","purple":"","blue":"","sky":"","lime":"","pink":"","black":""}}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:59 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/59b9327bb2db28f633257d4d/lists?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398799702'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '675'
+      Etag:
+      - W/"2a3-8c25cc83"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:19:59 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=d4bb2a06798cf66ff54ba066fa5a93427f570ae064c34e585d9aa362ba2dd577; Path=/;
+        Expires=Sun, 17 Sep 2017 14:19:59 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"59b9327bc2d2d0f4d8473d92","name":"Ready for Estimation","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":4096,"subscribed":false},{"id":"59b9327b14df0bf32722d089","name":"Backlog","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":8192,"subscribed":false},{"id":"59b9327bb2db28f633257d4e","name":"To
+        Do","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":16384,"subscribed":false},{"id":"59b9327bb2db28f633257d4f","name":"Doing","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":32768,"subscribed":false},{"id":"59b9327bb2db28f633257d50","name":"Done","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:19:59 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/boards/7Zar7bNm?card_checklists=all&cards=open&key=mykey&lists=open&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398800491'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      X-Trello-Index-Last-Update:
+      - '287'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"K6Pde3f2KAjv5XASW07Gpw=="
       Vary:
       - Accept-Encoding
       Content-Encoding:
       - gzip
       Content-Length:
-      - '1616'
+      - '587'
       Date:
-      - Thu, 08 Dec 2016 13:19:38 GMT
+      - Thu, 14 Sep 2017 14:20:00 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=96454c3d332fba87d3bfcf9a5cc189418edcf8da6ca5f0d14842f6a07eadc594; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:38 GMT; Secure
+      - dsc=31e540ba6695f389e82854a83c4600d8d68a37cbe14888d5304ab78ee79386e6; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:00 GMT; Secure
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+2YjW/aRhTA/5UnV9OSNQf+tkGqJkKaLFLWdiFZ2qVRdbYP
-        uMX4PN85lFbZ3753BgfoQhMm2qRaQQL7fO/53fv4+Z3PPxo8MdqGF7otL/Ij
-        l5lRy/P9AP+jyAqMHSMesvjyULFRT1HFpNHOyjTF4VRIhqJ9mkq2YyR47YhK
-        1YkVv+Jqgjpt0/KJZRMzPLGcttlqW1aj5bh/oM6EyRhndK4oT2nEUxRoQ/g0
-        fBrgN4Rn4ISwRcAx4QfIBJesDba/PRPco4rWVvBkV9CiWkEQJkk/tnyLhoHv
-        mW7oBInpx4aedMSlWrlKM6nm/MpGESvk70LpZZ1f6LHeUBQoaPuhPusoRePh
-        iGWqK65YUdswollJ02poPuPGMXhzGrEU/Xa+wsbQNvBmGR0xNLGXFzxTEHht
-        CBqW3QACVksfoI25QC2W6bXMAK+5oe0GbmihaVKbecSzS1TQ/eC/eH2WOjg/
-        oslAB+yjcSWqyJk7xhVnY54NpoudrXVmqSwjGRc8Whjqi0FUDj6g2sVEmGqa
-        n3b1kZbSo2Kklz+dQm/cMT3X0St4rrjIjLYqSp03Jav9iIddMcpTptjMgOvb
-        BpdkeFLdPMX4yjpos0BOT9Pa+XWirwrBPXOpDpPi8eVEO0WkAjPBiFI0asco
-        pfZz6FxfzKJyWqR4dahULtvNpipYmooGOqkZNxcidYvry7sFm5iXRFYJQwKP
-        BLrYrBb+Gtc7n6/rcPN1HSzU9QMWautrFeqBoGkb9vl7eJmzDH0YXwLPpKJp
-        SqsEr+vVC0Pf8hqBbTuBZdt2sFyvPbXbi0Rn/9HX67+L7/9WsAuhWq9ga0Es
-        2BYZYOKQPn9PBOaN1HlDlvLmjto1+5uu3dD3F2r3ZMhAMTqCIZWgs4MrTDpQ
-        Qp9UYQWFU7hOJKARFhOecwljvFmR8ow1QKuIMTASMJRiDLRgINEhKh6CXr1s
-        PCAgzFsBUSuMlxX6Gs4bxcbfMP2eQQdO4DkcwxEcwgs8ml2puWHbvudbZsNu
-        +W7LbfmOv8yN4+HB6clZePDouGF9f84vV/9CpNbDRi2I2DDJmFCiCCMFSQkn
-        GWF3PuRbmwWFjV3oYvP+5Al04pjlimYx1nuBRCg4fZu9zX6qCNA77T3Hsmej
-        GJcESIiI4j1BZHDEaA6u3bDrqTezxqK4RJRwNYTdl71fPne9K7JYlIVk+o5o
-        ywud+vr43DEbSLULLKuCZvhMRnTpfylLNhWVE60wgfGQI5FG9JJJPUNI4CM6
-        0PiTCvq4NWnAbjmAguUYYL2CPk9xBVRBHS5dNBzB3ZCYEFXUMBnG73C4EQ/4
-        zzx5ZpmWHVb91gMBL7gdeJvpiIJkAW2vLKsNW942HDMd6nnUMORpHfI53lqo
-        IVyJtyN776/fVPf1l8WbfzfenAfYxqyIthsb/xV8QbIm+E6zhBXzh/oCASea
-        UOMbBlrhfRi4EM71GFgLNjGRSW5ZxCNFlV6kTi8iMqLTi7g2uXvn429852O3
-        7gnFbirKBPZFmSXFROOkKLMMk1jXx3wPUUo9pFss3R9WENV1c1NN0/ZKt1Fa
-        BbKtopUaUlUJJSxPxUTnKnJLlqlCqGVAK3JqxVWribY14FD9KCETCjIWMylp
-        wdMJjBhFSdQaMW0e5KxARqC2dNLQa9ibq09EXOqDqmuFrfP5EpavoJVDVrCL
-        rTq+A2RwGVXx1ctrxtov/albmmN+yZuVp8jMU+RwoTsmByVPmA5572WX+Nvb
-        Wn2Z61jNelREGSCD9cnUF5/4fdHZb7MHbESDr8dle8rlvZk/9peccENkx3ID
-        315J5PzPydluMrS+LJHdx/liaRWR3W+WyAvhXI/ItSB2pQES2UYiTwuNxH1d
-        mDfb2jtZ7G2exfdtUD/H4s5Z75FT+JhJbH1xUaXU/erMZjQk4TIupW6zq0ZX
-        m5KXUcpjqCBbbex3tEmVuKx25v2C4fwyx3YYMY12sIQlD0pG/+uR0UEyup+Q
-        EX05Z6JjWa6/komhKIUquuPvTJxH2Pl2u9SFcK7HxFoQmegjEx3iLjORjuWd
-        NDQ3TkMzfBzv5K21Xrl5m37l9k5/oAfPoQO7+LsH72afeZm7geesftfmHJ2+
-        euPtvXn079q+v6NfCNV6JVwLYglbRBJGKInwNzGuL/4BOmx8wSUfAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:38 GMT
+        H4sIAAAAAAAAA61UTW/aQBD9K5F7pcUGg21uITRSqipNFXJplMPsemxWrHet3TVVivjvncVQPoJSVHobv5md9+bLy0DkwSgYZCzr95IsCRmwJMM45r28zyDoBAoqpIjH2gjlrsYaTE5ojpYTurEm4CAYqUbKTsCltkg5C5AWO5T+mylBiV/ghFbboFootRfUGEnJZs7VdtTtOoNS6k9cV13WTX6ASdh91bVrAR/ZRoCdaeOe/v6OQmuDhQ1Gy6BGUwlrScdXXKB/SjkX4JCCFtoJVRKUCwtMouegTBUqR2+DCiuGxhIo1EK4dTGHuEVZfNGCSnSmoZo46bzRC+/cQ67LlsVg2UgwngQkqhzMLWL+WbXU274w4PPS6Eb5GTHZeKE77K6CErcdPYIffdr8rXMqJJ5IPzainDmF1tdEYuYHRGPtnK5utNSG3B/CMMnGtwcRU12/537r46DG+NAwKfiuPQTRshx8P2wGtMPufP83wKoTSGAo72lH1xMuDaJq9/LVL8PP1tYGlG+Vt41vizfqxtRyA657u7bs/LU1pKg2EC3rfBtGJXlz1U6TOJ9ffKj1S/K8PDgmYHkvHQ6jJEszPujHw90xTbTfghO30p7Xu/dYa6LqhXFKWhtmuRHsT4pV50hCwSEJIxhAkUQxZ/FOwvfrS/jjMBuewZ+leYFp3E8HSYFRtM+//Z9QQ6W+qBdplPXO0XL0nu20TPXVRF8iIRr20/gfNPD/uBLkG56zE8cJ8n0NCi/aiiwanBzFy+o3mGpRomgGAAA=
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:00 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb17/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/lists/59b932798dfe843857fe11b4/cards?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -2065,7 +1746,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -2075,1552 +1756,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203178751'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:38 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=cb260590e21ed8f0986da7459e24b7618e0ced3e07e6c64fd3c0d4dc281a9958; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:38 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:38 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb18/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203178996'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=2b7b5d5455629071e7cad1617007db44fb2de711f0dc64df0c20dbd28b98fc69; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:38 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb0f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203179236'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=52169544e221fb3785455d616ca85b2df6c0873f1dcd87091eaa7ef426df03ee; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203179461'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '124'
-      Etag:
-      - W/"7c-1a0c1e2b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=4e7784f77103a95e36cd106854ea06967a9da9c5c43492feb572d8f2e8b67c56; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":18}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/577b6e6e00d1313a68d3a60a/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203179726'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '674'
-      Etag:
-      - W/"2a2-402ce24c"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:39 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=7e8ede16d7cdd2aa53de11d50840efd3e77e09efba5c8f13f29affbb28a14bcd; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"57a78bc5980cdceb09195dc9","name":"Backlog Backup","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":36863,"subscribed":false},{"id":"57ab15db6568cc9735820ee3","name":"Backlog","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":84863,"subscribed":false},{"id":"577b6e75ce0f88ec9af823c0","name":"Done","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":131071,"subscribed":false},{"id":"577b6e78ef9a4b2cb2f08ed0","name":"Doing","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":196607,"subscribed":false},{"id":"578e03cf104153b060cc27bd","name":"Ready for Estimation","closed":false,"idBoard":"577b6e6e00d1313a68d3a60a","pos":344063,"subscribed":false}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:39 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203179981'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '124'
-      Etag:
-      - W/"7c-1a0c1e2b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:40 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=55fdd0015483167d3d25a7c549978d9e45ed07e92122feb2c9a9c357fa9ae2c2; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:39 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":18}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:40 GMT
-- request:
-    method: delete
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/idLabels/578ddfc161a876504837d07d?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203180298'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '16'
-      Etag:
-      - W/"10-3393249b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:40 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"_value":null}
-
-'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:40 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb19/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203180716'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"090EYxK1aBudb+yJ7TiKzw=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:19:40 GMT
-      Content-Length:
-      - '629'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VT227bMAz9FUF92YbYsWzHSQwMQ5sOWIHsmnYY1haDJDO2
-        UNnyLDlBV/TfR7lJmpduLxZJHZKH4vEDVQXN6WSWziciEylEYj7JsimeQrA5
-        HVHBixIszR/oxjhvRCO6UbBVTfkRagHddwxjjTXXFkbU9sLKTomj0NqUoi//
-        YBssJyuQdxcOaqyUHbsLb/ksrC9NXUPjEJKMKHeOy2rn42UBvkHrlGlo7roe
-        OxQ90LzptR7MhalbDQ52BB6PuqwcH2a4vsWgNvaIZYE3S27dqXRqo9w90o0j
-        lgUsDqLZJUtyNs/TKMxY9pM+kUDEyQk5lRJaxxsJBGk56BS/aW6aN+SyArK6
-        Wr0nFhtL0JooSwTHnsQ0ZAm8JWkcxnvoAbU13Z0lW+UqcvZ59eFf9wvTSNN3
-        FnxH5PLJb8jb10kUMhbekgvS8YaoxhniT2t7eEq1975gQbaVkhWp+R1YjzCW
-        qJqXQLCQI2uudEjO+pJ00JrO+QnWSuME3JHKudbm47HfrdKah7a3EOLqxrYy
-        218YDmWp3qniLYtYPGOz3bOdc8ePtvXy4kYUaiSwB6jizPBuUOt0KjLIIIoK
-        lrCEZ7MCPxGnHjToSCvr1XL9grBTSW89dskF6J0c0MOkofoMokSuWZSySSKi
-        LJIynopiqP4k+UPKqsJXoSiNzHunB6UuzAa6PfGaNz3XQ+gZcZhRH3FoeI3D
-        0y+M5eTV5DX5Bl4vz6tH3ei9bpBOa/wfwljs21tP5arD56L7zbgOk8ywEjle
-        xue/v7rFD8zr/48a40hBy1gwCbqBRLAnEZgm8CSCNA5i+vgX+TQkCkEEAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:40 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb16/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203180977'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '124'
-      Etag:
-      - W/"7c-11505916"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:41 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=56a49d73ef6c3e26ed4aa21dc72fca728079389632f07b1d51a200072eb674e5; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:40 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":17}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:41 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb16/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203181230'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '124'
-      Etag:
-      - W/"7c-11505916"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:41 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=805096c6e924ccc5c8847d136e1c18f90ad30f847de1ffacddcf0f75a5b28c09; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:41 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":17}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:41 GMT
-- request:
-    method: delete
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb16/idLabels/578ddfc161a876504837d07d?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203181515'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '16'
-      Etag:
-      - W/"10-3393249b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:41 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"_value":null}
-
-'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:41 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb16/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203181824'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"MdmvAjgsaracE5uxVrGUBw=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:19:41 GMT
-      Content-Length:
-      - '683'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VT30/bMBD+VyzzMJiaJmnTtM0blDEhMTGpsEkDHvzj2nh1
-        7Ch2WnWI/33ntNAyCe0lsc9333333d0zVZIWdDTJpiOe8wwSPh3l+Rj/nKc5
-        7VHO5BIcLZ7p2vpwSHp0rWCjzPIbVByaH2hGjAXTDnrUtdyJRvEj08Iuebv8
-        g2kQTpQgVtceKkTKjq+zcApRiC9sVYHxu2TMeybKw11CSFB7ZQ0tfNNiBtkC
-        LUyrdXec2arW4GFP4OUoy9yzroaHJzRq645YSny5Yc6fC6/Wym+R7iBJ8ygd
-        RMnkLh0W6bTI0v44n/yiOxLocXJCzoWA2jMjgCAtD41ij+bRfCYzbVtJrmxr
-        ZLMlypGmNQZVI9aQ2xoMchEr0rpg8iUQG2z38y8kG/QHxCFbAVr3yR2+LS3T
-        AcJbgvw9+jPfBUmotd0GcUgDrtXeEWUIIxvbrAKwMq7j1ifX/pMjxnpiQIBz
-        rFF6SypgGImoHAI9UkNTMYNoetsPNVwe4KUVbTiwIDw5fTiU8P4FWZbQwNNp
-        6X3tijheKl+2vI89jUN5sQi6LHayxBu1UnGnVLRXKroOlLXu0KKvrZIQ4WF+
-        O4vys7MA39ahVzLQFnYNDSntJlx2Wvyj+7HYj2bfuUvm2dHAfDw7PQoVU/rV
-        QckLy5puYcZjnkMOSSLTYTpk+UTiJ2E0OHWjrJULA/vwwW5lGX0KvjeMg95P
-        JN4wqEOfQDIUizTJ0tGQJ3kixGDMZYe+27q3kHlpG4xJp+NwO39bllmQ5pU4
-        NrVlujMdPN5q1EccDKuwePo9HRTkdHS2nwAyu3qnJBKpLUYMB7gPuJMukLhv
-        UCj62nbf4PTaru0irn9vf17IMsW49v9eMRYT1bh4o2jX00gswgyEDXFd+pe/
-        htL+/LgEAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:41 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb15/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203182058'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '124'
-      Etag:
-      - W/"7c-10923321"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:42 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=d4f0266d9cf3c4afbde08b23126e088f94caa8d3dc85b7c45608e03e4d452846; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:42 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":16}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:42 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb15/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203182308'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '124'
-      Etag:
-      - W/"7c-10923321"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:42 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=3724b99e01b53dd289eb411af4a5b39c7e233152b5399e8e2086495add8513ac; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:42 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":16}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:42 GMT
-- request:
-    method: delete
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb15/idLabels/578ddfc161a876504837d07d?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203182618'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '16'
-      Etag:
-      - W/"10-3393249b"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:42 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"_value":null}
-
-'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:42 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb15/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203182952'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"IypsQxfll7SFf0IZVQ0lVA=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:19:43 GMT
-      Content-Length:
-      - '640'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VTy27bMBD8lQV76AOWLVmyLPvmOg0QIAWKOmmBJjlQ1Nom
-        QpECHzbcIP/epewkvgS9SFxyZ3Z2OXxismFzNqmK2aQu6wLTejYpyyn96zqb
-        sAGrebNBx+ZPbGd8XKQDtpO4l3rzHdsa7S/aJo41Vw4HzIXaCSvrs6212dRh
-        85fKEJ3Yoni88tgSU3EeLuMqoohfmLZF7Y/FuPdcbN/iBmOBzkuj2dzbQBWa
-        gGyug1L9cmnaTqHHk4Dnsyorz/se7h5oUxl3prKhk2vu/EJ4uZP+QHLHaVYm
-        2ThJq5ssn2ezeTEeVlX2hx1FUMaHD7AQAjvPtUAgWR6t5Pf6Xn+BpTKhgUsT
-        dGMPIB3YoDVNDYyGxe8VBBcDv0UwHerV7eobEP8YHOkUqNQQbuhsY7iKYG+A
-        lHvK574HNdgpc4hjAYsuKO9AauCwN/YxEkvtelVDuPIfHWjjQaNA57iV6gAt
-        ckISa41RGHRoW66JTR2GUf1PdCZYaio4vsEXzSSkkU4ER5ODvfTbXkoXaiUF
-        iL5hj7wdREk93AG3CGuLlB862G+RQk0RNvf6NMcL7vnZ9b1/kwOGLZfqJUE2
-        Xw23vX2n07rEEtO0yfIs52XV0CflLCb1xlLSRfvcveP0XLCHmHvNa1Qnf1BE
-        oJ69wjQX6ywtsklep2UqxHhaNz378Q28QlZbYwmTzaoYLV6tuzQ7tC/CadCB
-        q37rLeO1R3WmQfOWmmc/yH7wqfgMF/2lw/LydCEkoTOUmxdFWtJzcrH8raUR
-        sa33nZuPRt6Sl8yQntRIjCoTjLfLPeHC/7NG1EbSZXlSJEe3JWKdGJ3wvWPP
-        /wAxt8bIOgQAAA==
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:43 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b6b4e0b95667e0bbb10/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203183199'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:43 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=a14e76239b7e0ccfb2960939b44ddc90054ea2ec596539605ea0c50e585c77ec; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:43 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:43 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203183462'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '546'
-      Etag:
-      - W/"222-273e1966"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:43 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=3a2027de5f1ed6905b407a55702e66071f1f93ec52ab6da0d2219dc56fc19027; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:43 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
-        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
-        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:43 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203183709'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '546'
-      Etag:
-      - W/"222-273e1966"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:43 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=3ec39b354cf38f4c1776546060ebfb420aea4fe33b965c9476cbd8bb8f4407ad; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:43 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
-        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
-        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:43 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/lists/58495b7d44db45802c4a9b6b/cards?filter=open&key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203183995'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"a0bDA6HDgBTkFuVDFPcyKQ=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '2444'
-      Date:
-      - Thu, 08 Dec 2016 13:19:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=03e0c300503029d89a73294032040badefa86ba70839b1f80aa6e294ef8f283e; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:43 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+1YbW/bOBL+K4T7pS1MW/K7DRwWbdJ2u2jStG66i22KLCVS
-        FmtJVEnKrrvof78ZUrKdommSu/SaBQ7wB5niDIczzzwzo3d/tyRvzVrDyWA6
-        jMZ8MODRYDgJevGATaMRb7VbcSri5XMr8rllVpjWrKiyDJYzZQSIJiwzot3i
-        8O4FM/ZRbOVK2g3o7AXhiIY9GkzehP1ZMJ31h51wFP4JOrkwMeyonw6ZZY1a
-        yR8rpp1J4wnnSQwSbDIeDYPBpD/mwShu4aYX0tjLzY7cniORR0Kbt8qine/e
-        49o8VRoEe+Me/ntkLYvTXBT2QK2EbmzIWVGxzC3tdmxvCoezSGTgiHeX2Djp
-        teCwguUCTDxkMtuQeayrnDBLwnDWD1jeJh9YsVCVNR1TGdHhok20Ujk5ax1k
-        quLkqaoKrjdn6KNSwWE9UB60WwYv8EIWS1B9+vLt6z+i6CNsiRhfYGz+bq2U
-        CxJsXUmxlsXCu6H2Qn0HU0Um1jLaW0rUIqoWn31UtjH3mnZ/D/AJpXBV5egY
-        v4VtHeX/Y1y1LK1UxQ4jlWhcDI8HKi8zYUX9+su3Fi/ISO5OzyD0polnHWP/
-        N2vi0oD6suhcE2Z1BOdWxssNekVlCkDSijIwqt2CuMFhk/6X93VYTnUGb1Nr
-        SzPrdq0WWaY64KVu3N0L1Td8X10t2AXIUo5YogaxRJmlYUgRS7SBEkUoUS4o
-        IonGiCOaeBy1vrS/n+ni9jN9cjcyvf+/yvQ3guUzwiIF/m4TxqskAX/CkzI2
-        VUmbxCkcKjQ8GHgEDshZrjTLhIFHMKVQbWJWKsuYTdvEpuAdULAlgOEo+IoA
-        Hoevjt/KT3/+nwDuPAHshepmBNAIAgH0qQWIUY8w2gCM1viiNbyoRxfdgot6
-        bNEGWnSLrKtIIbl1Upjul/83qYAUMFZoEmlWxClRCcAeF+NUFkJviBaAfWkV
-        PMasIJEgsiB2rYhx1szOirPiIXn48KylSlGctR4+bJN1KopGrzQEX5BEaVKI
-        NYkVF3CEVtUiJbnQC8gPUsKN4KSPlQBgEa8u0erzJQoj4YTANKYFd6oZiGeC
-        GUFYwUmhiIJraEh4YGZhCOwjDEK6hu3gfLhBCt4DvQoujspq5c6pmli1Vcii
-        TPi7kvuyIzqohgDuNF1JI/Hl/hngEUhyEm2IJzby6pEzCIWWhVoXjZkU8Aeg
-        hh2Q8l42kZ8Ef9BBh54a4cLw1xFbCuLY8S+SAeXA1eESaJ8R1m1xpjmhe/fu
-        EeBQwHWFOW9wrQE0EgUsddZyKXPBJesovejiv+5TmYnZ81ica8X4uSzOQev5
-        MeRSuobLnL8RWmP4pTDnlHU+lIufWEkG36wktcJJcFFhhMlzSX2xurpWeRlj
-        /32NyuNSE5PH46ipGGEQjPq9iyVjkbOTqV39dudKRv+rkuF9dDcqhovDTSrG
-        acEhj9cQFQ15I/ZKxwapfb0tHuFwx8F3p1jtgeRmxaoRhGI1oI4bKBSmGpVX
-        VJtxePvVZrpXbZCf4liUFioN0CbQitCS+QKClQiQTKJMxUskZC7KTG0QmphW
-        R9KyJUPux3qkkWOBA5H/XJNNsCx7DiTHmEr43Khcsz0pGAAbv2HiSKjHfv5D
-        90FU1uew3IkX8hfJ/xUG4aA3mvxEwhveRuu8o6mTcEbuhw/Ia+eOxqtw422L
-        G4aTcDjo9KajwXQwHfVHF8kr//X3zx/mh89/LHn1riav8Ip+90eQ12Vpw1vf
-        obVrJPueU2+W7I0gJPuQliENqcc5zV1gKQb2qpzv3XbO94LBXs7vZZvMePOp
-        pVtq9UHE1mVc91CsRDZzX11m45kHZZPAu/SuO1TIYZX4JrWGb9P4ycK1bQa7
-        QqzGu861Q34X0Hx60sixpTIVNmspsIG0rq81FqgAu1vPO4LXLdX3GYtDR2eh
-        oWraZrMBns2RpmKlNJcFQ85ZS5u61wcnz2um8uKPX85/dYsNvRXGnwQK1ko7
-        HgTyEp9K8BWSV+I6dbHjR+x+tcrh2s1+YAMDGdBYtPVR44v6bO0OYSQBr0Qs
-        XpJMqXLP0p3bYdipfKuphakya1DDs9dPwKEWD8W7ggeqWvrozSmeHQ6D4GtC
-        fheGHfghaN6Tg0prSN0MOuWlDzJX0EQXykJwSkdPNq353lveBqJyhjS2708N
-        fshYpxJmGMa58cJJVcTIBywDvO5z/wJMrSKXRvPT+RPq7ttllVU5Q4Eu6u6G
-        g36AZo93Zp/sn4nv0RQcYyASDoC+1Hbg1lvEVXU3X49YrNjAXIg9+wXNj7Hy
-        gQDwDwo1lsoi0axTVGJXpuYiS+ZCr2QsuofSlBnbdFKbZ1iyhtNg2ENnH/n5
-        A2wSmjkn+CnKcyQURQmTlhvK3ECm6snOTzpaML5xox3FxVirdcQ0qeRMixwK
-        jrsOCuIGN4mAvILQrSSE5ZNb1sKt+F1nxUuHa4vu4tLEWLUE/8YJbkyL0QjY
-        zBBchdUq256Ghju7pTvVn/KNFy6XsuwSV/hMclevN7qwwwxWSJM2hsGgZElX
-        2LhbcbHq6gpm+Q7vjgNaYpZBoAtLIQ067o2LGgPnxAqgHSOvaO7y16YBqgNc
-        em1AE3CtRC66dQ51ZRInC4obt1qci/1rr+lCmgFlydK5uSpgspQJUqXEbkmD
-        YxfSTbNq59jGfbEqYZCH+CKfLMUGj3M2AbMmXa+iUwKHgWwjg0fg6/oE9A1G
-        RQIovTEeUz+xTRr9yC+M070576QHDdTkAXkmtt0TRIQtGGD4PtNxZbpQy6r8
-        wa6h6g+G/cmlDdW4r5+94k8OfmxDNbi6oRrenYZqEnyvofr+sDa94bB2wiR+
-        /7kwrTH3ybce14bXGdf2onizDq4RhA5uRMsendCF2LZvVUkdsqgDFnXAurKf
-        G9x+Pze55gx3LNYWaAOLdlUU2IyooqaxNcEvnmv8zOWZr9KOcFHsUMUVgs4z
-        MEhXJZrG8d3B/mZ8Z2vqcpUB6Qnkj+fENyLI/njetjeq+zH8Aod1pz7Iq34E
-        hZxpKxMoCcaVdNl8TNybPdHiHdlDt8JWTGbuoyDuhO5EK17FeNndyU5S+rsn
-        lYVe8z/umXY+haBBe4sfnOsvjP+kOXZ8y3PsCGh4+IAcOneTl9D7AdShi63d
-        hR7Dag+Nn/sk2wDhfikzARwtC0ioHUf3giAYXz70fpxHT4e6OPqxHD38Rw29
-        k+F/OfTuOfVmlNkIAmWOaTmiQ+qTjuIEYBAF0JIhCij8GhRQRAH1KKAeBNSB
-        oPXl/b8BE08s44IhAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b6d/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203184247'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=063951a503e5d4936713ea2c62ca4452d847620873cb46e9dedf27240b157e6e; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:44 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b6e/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203184526'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=e18cb59671dbf61a64f508cf7fd3761b6d5ae37124f015960ae8d6b1ec46fbc0; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:44 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b6f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203184754'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '236'
-      Etag:
-      - W/"ec-3965fc28"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:44 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=449d73b8edaa4e54041a2548c34960f81600e9d84dde78cd7414d775c7cc9a62; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:44 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07d","idBoard":"578ddfc161a876504837d06c","name":"Under
-        waterline","color":"yellow","uses":15},{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:44 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b71/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203185022'
+      - '1505398801292'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
@@ -3632,20 +1768,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:45 GMT
+      - Thu, 14 Sep 2017 14:20:01 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=1b39cb77e70524fb6f5728371a623cc7566f6b6835e0bb382d80eb55581e691c; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:44 GMT; Secure
+      - dsc=46843ca73e3ef2520d3f69769b22312ddfc9017952ce08b6b57dbd74d6586fb2; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:01 GMT; Secure
     body:
       encoding: UTF-8
       string: "[]"
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:45 GMT
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:01 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b71/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/59b9327970bab79e44c2d3ba/lists?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -3672,7 +1808,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -3682,7 +1818,71 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203185321'
+      - '1505398802054'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '795'
+      Etag:
+      - W/"31b-dcae71d2"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 14 Sep 2017 14:20:02 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - dsc=d77a716db4ee76ea834d05524263d11bcee29aa33d97ae32b90df6d0fbd7e157; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:02 GMT; Secure
+    body:
+      encoding: UTF-8
+      string: '[{"id":"59b9327abd286617989c5346","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":2048,"subscribed":false},{"id":"59b9327afca701a5af714cb4","name":"QA","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":4096,"subscribed":false},{"id":"59b932798dfe843857fe11b4","name":"Sprint
+        Backlog","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":8192,"subscribed":false},{"id":"59b9327970bab79e44c2d3bb","name":"To
+        Do","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":16384,"subscribed":false},{"id":"59b9327970bab79e44c2d3bc","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":32768,"subscribed":false},{"id":"59b9327970bab79e44c2d3bd","name":"Done","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:02 GMT
+- request:
+    method: get
+    uri: https://api.trello.com/1/lists/59b9327abd286617989c5346/cards?filter=open&key=mykey&token=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, must-revalidate, no-cache, no-store
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Trello-Version:
+      - 1.1044.0
+      X-Trello-Environment:
+      - Production
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Accept, Content-Type
+      X-Server-Time:
+      - '1505398802823'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
@@ -3694,86 +1894,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:45 GMT
+      - Thu, 14 Sep 2017 14:20:02 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=80a819aa1848cd603fe2411827ac2231699fcbffa59c343f34f4043733977412; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:45 GMT; Secure
+      - dsc=6586715cc82767c3dbc1156cc2b36740982f5b553e216665a3ac0f69f83f26e5; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:02 GMT; Secure
     body:
       encoding: UTF-8
       string: "[]"
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:45 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b71/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203185696'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '948'
-      Etag:
-      - W/"3b4-504c3a98"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:45 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"id":"58495b7d44db45802c4a9b71","badges":{"votes":0,"viewingMemberVoted":false,"subscribed":false,"fogbugz":"","checkItems":2,"checkItemsChecked":0,"comments":1,"attachments":0,"description":true,"due":null,"dueComplete":false},"checkItemStates":[],"closed":false,"dateLastActivity":"2016-12-08T13:19:45.637Z","desc":"##
-        Acceptance criteria\n\n* The bug blocking deployment of Mitaka is reported
-        to the cloud team\n\n## Notes\n\nThe bug was reported at https://bugzilla.suse.com/show_bug.cgi?id=1014268","descData":null,"due":null,"dueComplete":false,"email":null,"idBoard":"577b6e6e00d1313a68d3a60a","idChecklists":["58495b7d44db45802c4a9b7d"],"idLabels":[],"idList":"578e03cf104153b060cc27bd","idMembers":[],"idShort":199,"idAttachmentCover":null,"manualCoverAttachment":false,"labels":[],"name":"P1:
-        (1) Report Mitaka bug","pos":360448,"shortUrl":"https://trello.com/c/mHWzjSDI","url":"https://trello.com/c/mHWzjSDI/199-p1-1-report-mitaka-bug"}'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:45 GMT
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:02 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b72/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/59b9327970bab79e44c2d3ba/lists?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -3800,7 +1934,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -3810,32 +1944,34 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203185932'
+      - '1505398803621'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '115'
+      - '795'
       Etag:
-      - W/"73-6446cd67"
+      - W/"31b-dcae71d2"
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:45 GMT
+      - Thu, 14 Sep 2017 14:20:03 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=f57dc2860c960463a326cd3592c0bb1a05dbb2b77d93f902c91aae1e7597ca01; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:45 GMT; Secure
+      - dsc=82009e1e244e2cda7f98c622099609bdf432e14f9b88b739e53fa5feb6ad5067; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:03 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d089","idBoard":"578ddfc161a876504837d06c","name":"Pairing","color":"black","uses":85}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:45 GMT
+      string: '[{"id":"59b9327abd286617989c5346","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":2048,"subscribed":false},{"id":"59b9327afca701a5af714cb4","name":"QA","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":4096,"subscribed":false},{"id":"59b932798dfe843857fe11b4","name":"Sprint
+        Backlog","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":8192,"subscribed":false},{"id":"59b9327970bab79e44c2d3bb","name":"To
+        Do","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":16384,"subscribed":false},{"id":"59b9327970bab79e44c2d3bc","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":32768,"subscribed":false},{"id":"59b9327970bab79e44c2d3bd","name":"Done","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:03 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b72/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/lists/59b9327afca701a5af714cb4/cards?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -3862,7 +1998,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -3872,163 +2008,7 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203186186'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '115'
-      Etag:
-      - W/"73-6446cd67"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:46 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=f42623b0f401c3bc19a021a88326d46f3120f998c321302268afeb0614299fe0; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:46 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d089","idBoard":"578ddfc161a876504837d06c","name":"Pairing","color":"black","uses":85}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:46 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b72/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203186600'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"2J8wr5u2UneKQq7TdDtamg=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:19:46 GMT
-      Content-Length:
-      - '1286'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA41W247bNhD9FUJ5SYrVxVd5BRRFsgnSANlm201aoMk+UOTI
-        Zk2RKknZcYP8e2coadctsmgBw5CGczlzOBd9SZRMqmS1WV6u6lIul7JerjbF
-        XCz5ZV3Ok4uk5nILPqm+JAcb6KG4SA4Kjspsr6Gtwf2KYvTRcO3hIvF97YVT
-        9Zmosdu63/6FYdCd2IHYvwnQoqfl+esVPZEV+he2bcEEVFldJDwELnbjOx5K
-        oABdUNYkVXA9RpA9JJXptY6PV7btNAQYAXw9i3IbeMzh4x0KtfVnKCWevOU+
-        PBdBHVQ4Idx5MVuns3labN7PFtXsslqus+Vm8XsygEANtguh81We173SMvO9
-        h0xC3jn7B4iQ+5095i/hALq60raXVVldq8D3/JP5ZN7vgAmSsgC8ZbXjBnFK
-        ZpuGBTwbNJkDDdwDUyZYxpmHjjuEivLOehWsO2XsN2AG0BQ1Wr4H5nsH6IMH
-        pgIT3DAflNasBiah0/YEMiMET56w50JAFzAyYnEqgFMR23eM0El7NEG1gJAi
-        In/yyCFTnglrnVQGcUh2VGEXj69u3sRUJvMX725/jMIxE2X8EAkdHK3bYwUx
-        7hl87pArdMQbjI8gST7hZI2zLaY96R/Aebz4CdE9RxMXY2wXg3DWICs1F3um
-        re3OkD7Qzmvbhyh04HsdPHl4/csrJDRQUMoVGehH6+v3Hyj2bFUUI4M/UVfQ
-        88fZLMMfFc0du+qdw4rVJ9buh0uWFjwzNuDldJ11FBMhPiC/YPUAZMLeYT3j
-        +Z89+MBsB4Ydd0rsGJfSD8ZNbwS1AddYrwxve6rGLULt6wyR57cfbl+lMd+c
-        98G2nAxy8p3PlouCYJcPsG/OY9I5QWnBbfEmYgG22CHgMsz6vuKw5iN/QwEz
-        bk6tdZD9y/MLbam9GfYnGU1IlWkcz0wPQ+9ExKCbW3AHJSB/qXyn+SnbhVb/
-        oOT3q8tiNSeyr7npuSZM4HgkAdlBiobRwI5cBeTHOmRcxoA1dRD2wdA6XJ4q
-        cpOSUDh7rLljvaoctPYwpEOGpOAhRHuLV3dQeC2fo9hBlAxan8y7WNeB6JLK
-        C3TiQH4jAuMaiSAQqMypuExwVt9HI+ARt4pRhyjfOIi9pPUjVAydFFMfFeO1
-        s0YZ5XcTMJDoK4cg8l7CIXe9Bp/JvCzSjroML9qEFNsgiyfx1jiSIyyWtqC5
-        4mTs37AryB3W5eANxwSm1ahtPvZQrhrRbFNSvPcSKR6OB0//aDMcWaqLNPeG
-        7Y1qaFQqxIOMONgSNsfsA7ETfcJ2JxRCHEx7OFG4iAkna5MPLrIOZxjaTjYU
-        go7HCMQN3YrCohzADDU1Dv2XPPCzXfP42rlIoOVKTwpKvrCYJu3asqzXsIai
-        kLPFbMHXG4l/BU9IKW5BjfnRknpkLW+K5I503/Ia9KBXboQEMdssYV2WjVys
-        N029KlejHrqLcTdQLEQzK5az1aIu1oUQ87KWMe6wysfNqOTtDidUUs2Lgt6e
-        32/gKyrsKaU2Fl4UPWjcZ68ndF/GT4zHMP5PbgxvkdrkhiuHi4C+JKy2iCWp
-        NQ54fMf5QR8My693D8rzij3dPGOvsYfHVYEVxrcce/Ipd6L3Oe7mvn2G5jiH
-        k2pRrjeLOX7FUP4fHN5eMk2qgItY2zihRF4u3Ouf5asrCvvfWjnymHbzdJNu
-        IaRtBJL2XRqBpBFHGnEkX/8Gjy8ukJAJAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:46 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b74/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203186822'
+      - '1505398804405'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
@@ -4040,20 +2020,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:46 GMT
+      - Thu, 14 Sep 2017 14:20:04 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=0bf5dfafdbb205af84ea8c1fb37b68acc9f90b99d2e706267950aaeaf9b74ddf; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:46 GMT; Secure
+      - dsc=e3d48bc1cd74e97e324b4a7bed0f5b7650f6c05107f6fd7ec56f9225749f207b; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:04 GMT; Secure
     body:
       encoding: UTF-8
       string: "[]"
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:46 GMT
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:04 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b74/labels?key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/7Zar7bNm?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -4080,7 +2060,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -4090,114 +2070,34 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203187115'
+      - '1505398805267'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
+      X-Trello-Index-Last-Update:
+      - '287'
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2'
+      - '825'
       Etag:
-      - W/"2-d4cbb29"
+      - W/"339-12abfd90"
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:47 GMT
+      - Thu, 14 Sep 2017 14:20:05 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=5893bbda413c46449abadf0d74ffe7cfe5c1ff56af53f71c56864ac1e13000ff; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:47 GMT; Secure
+      - dsc=f89f978c7bbc3354a41f750d34ca11dc45842cb4b30e8ad5cbf20b93c1b11e93; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:05 GMT; Secure
     body:
       encoding: UTF-8
-      string: "[]"
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:47 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b7d44db45802c4a9b74/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203187562'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"fcUmbT0zepwcH3qd6LwBcA=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:19:47 GMT
-      Content-Length:
-      - '742'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4VU22obMRD9FaG8JMVr79q76wuU4iZtKSRpqZM+tAlFK83a
-        IrK00cXGDfn3jnbtxC+hYIwuc86cmTnaJyoFndFikk+LaizyXFR5MUmHPGfT
-        apzTHq2YWIKjsye6MT4u0h7dSNhKvbyCdQX2Jx4jR82Ugx51oXLcyuroqDbL
-        Kiz/Yhqk4yvgD189rJGpON6ex1VEIT836zVojyFZjzLvGV/t93gpICZovDSa
-        zrwNmEEEoDMdlGqX52bdKPCwF/B8lGXhWVvD73s8VMYdqRR4c8mcn3MvN9Lv
-        UO4wzcokGybp5CYbzbLpLB/383H2i3YiMOLkhMw5h8YzzYGgLA9Wsjt9p9+R
-        a9h6o4l0xAatsV0Ed34FRMOWrJgVW2YRY3Qtl8GyWE+EXRgeYrHtQUSHJkoT
-        8e78ODjeeQvxjjCHRAJa/PWCbI19cKQ2ts0noFFmh1Fu57AHhGkRsWKfqKOe
-        K0WY9bJm3KNieAzSIiRydPgYSqLiBqyTSKS92hG2YVKxSkEbaaGxRgQei33N
-        3CJlV3sdfLCtzi8/PmEnfCcVBw5YKNlKvyJXN7fE1CQr0jR2Ent8HZ0X1689
-        xaEZwuoaeKy/2pGV942bDQbRalIp1nfBQR+JB25ltn/wuM+X8oMU77M0y4fl
-        ZD/FC+bZkXne9lGPwhqLPQRI8dHgEOPjGY+rEkpIU5GNshErJwL/UkZjUGtr
-        hf2KrnvjnU0Keh9jL1kFau9O3CGoZZ9AOuJ1luZZMarSMuV8OK5Ey969wBfI
-        YmUsYtC3cTd/eTjnZgP2IHzNdGCqPXqNeKlRHWnQbI3F0+/ljJwWZ+SinSb5
-        1oDGd8QfDg6PA0EbWc0UwTn5g89OG6kguIHUPLgz1NsYJB5NR8OsxA9F1Hpr
-        sZ/0MDp0s1KmnRkfPC6qz4XVV4gL/48aYM1JUyZF0nkuMajSRZWJblUm+Duo
-        TKLKpFOZdCKTViR9/geFI9AfEAUAAA==
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:47 GMT
+      string: '{"id":"59b9327970bab79e44c2d3ba","name":"Sprint Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/7Zar7bNm/sprint-board","shortUrl":"https://trello.com/b/7Zar7bNm","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":true,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundBottomColor":"#0079BF","backgroundTopColor":"#0079BF","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"","orange":"","red":"","purple":"","blue":"","sky":"","lime":"","pink":"","black":""}}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:05 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/59b9327970bab79e44c2d3ba/lists?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -4224,7 +2124,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -4234,34 +2134,34 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203187826'
+      - '1505398806039'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '546'
+      - '795'
       Etag:
-      - W/"222-273e1966"
+      - W/"31b-dcae71d2"
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:47 GMT
+      - Thu, 14 Sep 2017 14:20:06 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=05776f7e9fbf6a0cbee4e6d27587ddd74fb19751aaa1977db879553af1cf7b0c; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:47 GMT; Secure
+      - dsc=9dbfe886d5227e164706ec55a11d1a70463c9b72d9e639b751fcc009316be39e; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:06 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
-        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
-        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:47 GMT
+      string: '[{"id":"59b9327abd286617989c5346","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":2048,"subscribed":false},{"id":"59b9327afca701a5af714cb4","name":"QA","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":4096,"subscribed":false},{"id":"59b932798dfe843857fe11b4","name":"Sprint
+        Backlog","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":8192,"subscribed":false},{"id":"59b9327970bab79e44c2d3bb","name":"To
+        Do","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":16384,"subscribed":false},{"id":"59b9327970bab79e44c2d3bc","name":"Doing","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":32768,"subscribed":false},{"id":"59b9327970bab79e44c2d3bd","name":"Done","closed":false,"idBoard":"59b9327970bab79e44c2d3ba","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:06 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/boards/578ddfc161a876504837d06c/lists?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/72tOJsGS?key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -4288,7 +2188,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -4298,34 +2198,34 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203188092'
+      - '1505398806865'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
+      X-Trello-Index-Last-Update:
+      - '164'
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '546'
+      - '829'
       Etag:
-      - W/"222-273e1966"
+      - W/"33d-25f949ca"
       Vary:
       - Accept-Encoding
       Date:
-      - Thu, 08 Dec 2016 13:19:48 GMT
+      - Thu, 14 Sep 2017 14:20:06 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=f59e544316fecf33a84516e2265807af5b76dee9dfae2b1c61658ab4f12ddcc3; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:48 GMT; Secure
+      - dsc=2889d67bfdb35bba2f6f08e232831e6270200195fab5a95ba4c9662183e1a511; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:06 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"58495b853ea992256749003d","name":"QA","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":2734,"subscribed":false},{"id":"58495b7d44db45802c4a9b6b","name":"Doing","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":5469,"subscribed":false},{"id":"58495b6b4e0b95667e0bbb0d","name":"Sprint
-        Backlog","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":10938,"subscribed":false},{"id":"578ddfc161a876504837d071","name":"Definition
-        of Done","closed":false,"idBoard":"578ddfc161a876504837d06c","pos":32770,"subscribed":false}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:48 GMT
+      string: '{"id":"59b9327bb2db28f633257d4d","name":"Planning Board","desc":"","descData":null,"closed":false,"idOrganization":null,"pinned":false,"url":"https://trello.com/b/72tOJsGS/planning-board","shortUrl":"https://trello.com/b/72tOJsGS","prefs":{"permissionLevel":"private","voting":"disabled","comments":"members","invitations":"members","selfJoin":true,"cardCovers":true,"cardAging":"regular","calendarFeedEnabled":false,"background":"blue","backgroundImage":null,"backgroundImageScaled":null,"backgroundTile":false,"backgroundBrightness":"dark","backgroundBottomColor":"#0079BF","backgroundTopColor":"#0079BF","backgroundColor":"#0079BF","canBePublic":true,"canBeOrg":true,"canBePrivate":true,"canInvite":true},"labelNames":{"green":"","yellow":"","orange":"","red":"","purple":"","blue":"","sky":"","lime":"","pink":"","black":""}}'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:06 GMT
 - request:
     method: get
-    uri: https://api.trello.com/1/lists/58495b853ea992256749003d/cards?filter=open&key=mykey&token=mytoken
+    uri: https://api.trello.com/1/boards/59b9327bb2db28f633257d4d/lists?filter=open&key=mykey&token=mytoken
     body:
       encoding: US-ASCII
       string: ''
@@ -4352,7 +2252,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Trello-Version:
-      - 1.823.0
+      - 1.1044.0
       X-Trello-Environment:
       - Production
       Access-Control-Allow-Origin:
@@ -4362,399 +2262,28 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Authorization, Accept, Content-Type
       X-Server-Time:
-      - '1481203188347'
+      - '1505398807660'
       Expires:
       - Thu, 01 Jan 1970 00:00:00
       Content-Type:
       - application/json; charset=utf-8
+      Content-Length:
+      - '675'
       Etag:
-      - W/"IJIJu+DEh2ZzZl81HB32og=="
+      - W/"2a3-8c25cc83"
       Vary:
       - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '1481'
       Date:
-      - Thu, 08 Dec 2016 13:19:48 GMT
+      - Thu, 14 Sep 2017 14:20:07 GMT
       Connection:
       - keep-alive
       Set-Cookie:
-      - dsc=697351944a684ba5b6dd2627b6a908f95bd8f237be9d0b360fe8a71fe3734196; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:48 GMT; Secure
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+1Wa2/bNhT9K4T2YQ9YlvySZX/Lsg4IkHRpk67FmgKlKMrm
-        TJEaSdlxi/z33UvJr8Jum61b92FAEFgS7+W59x6ew9fvA5EH02CUDiejLB0N
-        OJ1M+v1RMh5O4ngYB52AzTlbXDhe3jjquA2mqpYSXkttOYQWVFreCXL4dkmt
-        O2NOLIVbQ85+3EvCXj+M09veYBpPpsO4O5okv0HOnFsGK8IwvFP83nGjqJwS
-        Z2p+p4Q6fLaMbX62kT9RRzcwRP6jpsaXME7zvGC9pEfTcTKKh+lgnMcJC3DR
-        pbDuZJmD3K+54mXGjf1VO6zr9Rt8dzPXBgL74wk+nTlH2bzkyp3rJTe7hOPD
-        hKMMEpZU1VT6hbu4YIqVeEQ04xK6+foE8LQfAAJFSw7b+NYTXZALaM7MUCe0
-        IrfcOgsbVRrS9Ebj0SBJu/EgjvvDcdIJLEK/FGoB8em7Vy+pnp3B6ozmM5zi
-        +2Cp/TjjTrAUfCXUrGlAW387V1tnlhmR7b0q9CyrZ+8g7T47mky7x3P8hVH4
-        VpdYfLOEbpsBz/1mokZUWNKmO3nNN/OFn+e6rCR3vAXwcOzlQYzI/eZSYH/a
-        QbbDbR7lpvcb9p+awGfyazslwRZrbIqWGtmRSQDVCWqLfU4HD2/aqbwwEr7O
-        navsNIqc4VLqLjQpYtHepI60vv50YARcDS3yJdRFKHZ8CZ3ny0Pno0d+UHzx
-        I59O9o787ZyTkgpFaL6kytGZpzW/r6Bj1GmzJggTyEiEJW5OHZHCOclJZXhF
-        W+bDJ8V5zvMOEWUFDYVMBDhpCTWcFLpWOfmjhmHIdYdQeIA0/J6z2kc7UfIO
-        5OaEVpXRQEbYU+WwnSYZoNOQA/smJWcOjrBcE0BU1pJ6XABK7WUD9A1/ee6h
-        2+6dulMv51yRta4hkhqHmZsSud+X6Rxg0lpRELa1T6pJIQCoLwKUY4EPc4p1
-        gn4QyyFdxgtI0CHMcFQDCt9WhAE5oWJDalVJqhSgWGmzwITOULZAEIb8Dv8U
-        X3toV019EFM23aSZrt3RETCKu7YNhZlhqpVYiCnm2bBwJty8zjwLb17cPImo
-        LAzPI1wXPdklDW+bpBj6FXU8/aiOJx/oeHJax9tD8Egh32sIaRuyUfBBbxSP
-        B0k3TsB4J6P+oYJfJTP27pq9+s8peO9/BT8U4r1JPU7BN4Gg4Gm4dxzD9jh+
-        SrqHvS9/Wxt+IN1LKkWOqFoFpBlIM+pUhgqFUgwCVBhdEjuH0lCGntfZuksw
-        +Pn1lV/b6CzNqRdNFC8U+g6xmghHKgBsUW0MBw0HKSEzICPhjnn5wkS4D5oA
-        q40BFoJAo6H4SB8F/ZqSI/oEXahzr2bQVaFYnWEpEStCXXEFUs0W4bbCCNNF
-        wy55yaEYXcu8gewVvIKl3rsUQ0kHLPBXcjMDuGg4MFdOoeMe8jffkDPGeAU2
-        BauBEHDBFdSL6A/kF9BUbAyMGNBntZC5xfeH3W6+orKDx9nWCsgKXUYgcPCq
-        tu976DDN2zBklQhbPG8RZkUdsCTfjAFk3R9dKgkabAlH0nTJRUGUhmEYvRQ5
-        Loa059cXx3ZD1d82BF2bLrjqtpsjZOBumMMkGbL57a4KgQKAMgLZ6srCYaAl
-        +Iub+7T8HlvmDRuvAcCMXHOrvnVgn3BxEKq10rISCAfAwW2g2A7DozgOcjOU
-        pyifnlPaWx7uAZel7GDCmGFHJj+frmcLaEJXm1nULoyAI6voHBk2vdVa2hO0
-        +prul8ZH3a/B8Hd9bowYT+jwZM8Cr0dT8t3ge3LmD9PxJm27DxzFWw5qCDm/
-        vNh6Zb+X9Mf9E155m7mfn/Wfr/5Zrxx+2iuHH3hl/C945SlzSIK/6qJj9kgX
-        fQp3c0uene356MyAP2yNdLBzslN8edyO11SY5iq1M25g0M65h5/j3Hu8eZxz
-        bwIjOGFhNQoHoXeK8Di5w5bcodMhkDs0QO6QSRE8vPkTuniuxo8RAAA=
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b853ea9922567490040/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203188614'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=6cf04394c232fdea3d2b9110696342e2f32b0cc2e1b4822049df92cc4063c421; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:48 GMT; Secure
+      - dsc=800884212c1fa85e7775031536720873a75570f041c791a667a88c3b1c0855f9; Path=/;
+        Expires=Sun, 17 Sep 2017 14:20:07 GMT; Secure
     body:
       encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b853ea992256749003f/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203188853'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '113'
-      Etag:
-      - W/"71-dcfd41be"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:48 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=2c9cd20c024ad39533ed0d9785f2ce43dd981c55358bc7b9086bc645b738077a; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:48 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d082","idBoard":"578ddfc161a876504837d06c","name":"Sticky","color":"blue","uses":83}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:48 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b853ea9922567490041/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203189100'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '229'
-      Etag:
-      - W/"e5-571096d0"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=d412942b4124d70a7e8e56023ff33730493e59cb6bd54679a77f2d01b408fe08; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:49 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07c","idBoard":"578ddfc161a876504837d06c","name":"Needs
-        QA","color":"green","uses":3},{"id":"578ddfc161a876504837d089","idBoard":"578ddfc161a876504837d06c","name":"Pairing","color":"black","uses":84}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:49 GMT
-- request:
-    method: get
-    uri: https://api.trello.com/1/cards/58495b853ea9922567490041/labels?key=mykey&token=mytoken
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203189379'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '229'
-      Etag:
-      - W/"e5-571096d0"
-      Vary:
-      - Accept-Encoding
-      Date:
-      - Thu, 08 Dec 2016 13:19:49 GMT
-      Connection:
-      - keep-alive
-      Set-Cookie:
-      - dsc=2b07d33dc7b0c5177113396b317c06abf9fc6ddea823ce7f727c576e30a287ef; Path=/;
-        Expires=Sun, 11 Dec 2016 13:19:49 GMT; Secure
-    body:
-      encoding: UTF-8
-      string: '[{"id":"578ddfc161a876504837d07c","idBoard":"578ddfc161a876504837d06c","name":"Needs
-        QA","color":"green","uses":3},{"id":"578ddfc161a876504837d089","idBoard":"578ddfc161a876504837d06c","name":"Pairing","color":"black","uses":84}]'
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:49 GMT
-- request:
-    method: put
-    uri: https://api.trello.com/1/cards/58495b853ea9922567490041/idBoard?key=mykey&token=mytoken
-    body:
-      encoding: UTF-8
-      string: value=577b6e6e00d1313a68d3a60a&idList=578e03cf104153b060cc27bd
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, must-revalidate, no-cache, no-store
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - DENY
-      X-Trello-Version:
-      - 1.823.0
-      X-Trello-Environment:
-      - Production
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, PUT, POST, DELETE
-      Access-Control-Allow-Headers:
-      - Authorization, Accept, Content-Type
-      X-Server-Time:
-      - '1481203189817'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"N0gQbVR9vrC1zgKVcSyU8g=="
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 08 Dec 2016 13:19:49 GMT
-      Content-Length:
-      - '984'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA5VVaW/jNhD9K4T2Qw9YlnzIh765bgsEyG6zSXYX6CZAeIxk
-        IhSpkpS9bpD/3iF9LuCgLRA4PB5nHt88jl4SKZIyKWbjecFmxQjofD4cFpPp
-        eJ7n40HSSxgVNbikfEnWxodB3kvWEjZS1++hYWA/4zLGqKhy0Etcxxy3kp0t
-        VaZmXf03psFwfAX8+cpDg5HG59NlGIVTGJ+bpgHtdxDqPeWr/Rw3BYQErZdG
-        J6W3HWYQHSSl7pSKw6VpWgUe9gRez7LceRrv8PURF5VxZywF7lxT5xfcy7X0
-        W6Q7zAeTdDBM89n9YFQO5uV43p/m0z+THQlE3K+ArKmSeNhYAt+Ad54yBWRF
-        HWEAmrTGojyksqYhbgVKEW/Ibce2fRIO3968j1hcZECooG1EYzC/or5HnCHS
-        kxav5ojUxMJfnbSIqFExAp73H/SDDoFCHiId4Z21KJXaBjiNJ+MpcL4kK+9b
-        V2ZZLf2qY32UOUMVOlGZTgu7TaXmHQtXyXiVmha0Q+mf0+MNsxAuG/fJF8DL
-        mE6JHWUkiwwQSmsgRnPABeSCfw3YGulSLZCFAoqKR8rv3pEF59B6GtBYTw9W
-        0jJs/Uz+6GwUxnmJ7FknlXBh/Xu1d7sbY58diWqjakA2KxRdBuJKHXQ/YxfC
-        PKUpb2W65/MUaLbUo0fEoQyamOgvqnDH0gbNZPvkqiLaYDGsWUsRwBh2eXN1
-        Kdvdp7vfjoJgfE+fQff3yQNlfD2pwEpyvMn26XQLGawbvI7RutZ5C7QhGyxX
-        DAvfgmRILLojOEMYcPoHT7jRnkodUVjWVgY6SK5HZHUsRmRxmeShKB/CG4+e
-        MgRHMUdtKfuuwiHCyUyxPv3ols5B39g62wMz9MgmWwaHlffGKPeGrR70/kX9
-        Sj09e8hvv+leAg2V6gCQ4hdDbWxk0ymbwATyXAxGgxGdzAT+5DQJoNhilHSh
-        kXx9q+dNkseAvaYM1AknKvwHk+m0EqMJZXMoBIYspjMugA9OW7OKFdNiHwIz
-        RUozyEe8GmA/LUYsn+ScD6dMREq7FrrvSFLcrfAZJ+UwH4bZ4tj5lmYN9nDb
-        huqOqrh0QhyFUQfiL/vW/hbH/yibRvsj4oZKi6YNHdwog1wSprCIOMeiY7qi
-        eO29nH1MLgv2fzJ+ABCOfFycpawtttRjysHr44leUZIfRz+RRWxHl2129C++
-        cg2b2IXJ8voKA7YmfGvy+STHD4wLRfhk0V3JweP4DpUyu4aZ3TP/+8fh7SYQ
-        +XdUhsVM2yIdpbFVppe5pXtuqTcpckstcku5ksnrP/LXJrGiBwAA
-    http_version:
-  recorded_at: Thu, 08 Dec 2016 13:19:49 GMT
+      string: '[{"id":"59b9327bc2d2d0f4d8473d92","name":"Ready for Estimation","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":4096,"subscribed":false},{"id":"59b9327b14df0bf32722d089","name":"Backlog","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":8192,"subscribed":false},{"id":"59b9327bb2db28f633257d4e","name":"To
+        Do","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":16384,"subscribed":false},{"id":"59b9327bb2db28f633257d4f","name":"Doing","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":32768,"subscribed":false},{"id":"59b9327bb2db28f633257d50","name":"Done","closed":false,"idBoard":"59b9327bb2db28f633257d4d","pos":49152,"subscribed":false}]'
+    http_version: 
+  recorded_at: Thu, 14 Sep 2017 14:20:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/unit/scrum/sprint_cleaner_spec.rb
+++ b/spec/unit/scrum/sprint_cleaner_spec.rb
@@ -8,8 +8,20 @@ describe Scrum::SprintCleaner do
   end
 
   it "moves remaining cards to target board", vcr: "sprint_cleanup", vcr_record: false do
-    expect(STDOUT).to receive(:puts).exactly(12).times
-    expect(subject.cleanup("NzGCbEeN", "neUHHzDo")).to be
+    expect(STDOUT).to receive(:puts).exactly(13).times
+    expect(subject.cleanup("7Zar7bNm", "72tOJsGS")).to be
+  end
+
+  context "given correct burndown-data-xx.yaml" do
+    before do
+      allow_any_instance_of(BurndownChart).to receive(:update)
+    end
+
+    it "generates new burndown data", vcr: "sprint_cleanup", vcr_record: false do
+      expect {
+        subject.cleanup("7Zar7bNm", "72tOJsGS")
+      }.to output(/^(New burndown data was generated automatically)/).to_stdout
+    end
   end
 
   context "with non-existing target list on target board" do
@@ -19,7 +31,7 @@ describe Scrum::SprintCleaner do
 
     it "throws error", vcr: "sprint_cleanup", vcr_record: false do
       expect {
-        subject.cleanup("NzGCbEeN", "neUHHzDo")
+        subject.cleanup("7Zar7bNm", "72tOJsGS")
       }.to raise_error /'Nonexisting List' not found/
     end
   end


### PR DESCRIPTION
Add automatic generation of burndown data when calling
`trollolo cleanup-sprint`. This assumes the burndown-data-*.yaml is in
the current working directory. The user gets notified if new data was
generated or not.

Fix https://github.com/openSUSE/trollolo/issues/68.