### PR TITLE
Make `move-backlog` to work without waterline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add a new `plot-to-board` option to the burndown command to send the plotted
   burndown chart to the first card of the `Done` column.
 * Add documentation for all CLI commands. Fixes #83.
+* Allow to use `move-backlog` without waterline and seabed cards.
+  Closes #106 and #107.
 
 ## Version 0.0.12
 

--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ re-record the stored replies, set `vcr_record:` to true and replace `dummy_setti
     describe Scrum::BacklogMover do
       subject { described_class.new(real_settings) }
 
-      it "fails without moving if backlog list is missing waterline or seabed", vcr: "move_backlog_missing_waterbed", vcr_record: true do
-        expect { subject.move("neUHHzDo", "NzGCbEeN") }.to raise_error
+      it "fails without moving if sprint backlog is missing from sprint board", vcr: "move_backlog_missing_backlog", vcr_record: false do
+        expect {
+        }.to raise_error("sprint board is missing Sprint Backlog list")
       end
     end
 

--- a/lib/scrum/backlog_mover.rb
+++ b/lib/scrum/backlog_mover.rb
@@ -5,7 +5,7 @@ module Scrum
     def move(planning_board_id, sprint_board_id)
       setup(planning_board_id, sprint_board_id)
       inspect_backlog
-      @sprint_board.place_seabed(@seabed_card)
+      @sprint_board.place_seabed(@seabed_card) if @seabed_card
     end
 
     private
@@ -18,21 +18,16 @@ module Scrum
       fail "backlog list not found on planning board" unless @planning_board.backlog_list
 
       @waterline_card = @planning_board.waterline_card
-      fail "backlog list on planning board is missing waterline or seabed card"  unless @waterline_card
-
       @seabed_card = @planning_board.seabed_card
-      fail "backlog list on planning board is missing waterline or seabed card"  unless @seabed_card
     end
 
     def inspect_backlog
       @planning_board.backlog_cards.each do |card|
-        if card == @seabed_card
+        if @seabed_card && card == @seabed_card
           break
-
-        elsif card == @waterline_card
+        elsif @waterline_card && card == @waterline_card
           @sprint_board.place_waterline(@waterline_card)
           puts "under the waterline"
-
         else
           move_sprint_card(card) unless @planning_board.sticky?(card)
         end

--- a/spec/unit/scrum/backlog_mover_spec.rb
+++ b/spec/unit/scrum/backlog_mover_spec.rb
@@ -7,12 +7,6 @@ describe Scrum::BacklogMover do
     expect(subject).to be
   end
 
-  it "fails without moving if backlog list is missing waterline or seabed", vcr: "move_backlog_missing_waterbed", vcr_record: false do
-    expect {
-      subject.move("neUHHzDo", "NzGCbEeN")
-    }.to raise_error("backlog list on planning board is missing waterline or seabed card")
-  end
-
   it "fails without moving if sprint backlog is missing from sprint board", vcr: "move_backlog_missing_backlog", vcr_record: false do
     expect {
       subject.move("neUHHzDo", "NzGCbEeN")


### PR DESCRIPTION
Having a waterline and a seabed card in the `move-backlog` command was compulsory. Not every team have this two cards, so this should work without them too. :bowtie: 

Fixes https://github.com/openSUSE/trollolo/issues/107.

The error message when one of this cards was not there was not clear, but as this error is not error any more this also closes https://github.com/openSUSE/trollolo/issues/106.