### PR TITLE
Prepare version 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Master (unreleased)
 
+
+## Version 0.0.13
+
 * Add a new `plot-to-board` option to the burndown command to send the plotted
   burndown chart to the first card of the `Done` column.
 * Add documentation for all CLI commands. Fixes #83.
 * Allow to use `move-backlog` without waterline and seabed cards.
   Closes #106 and #107.
-
 * Run `burndown` on `cleanup-sprint`. Fixes #68. 
 
 ## Version 0.0.12

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module Trollolo
 
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 
 end


### PR DESCRIPTION
- Add a new `plot-to-board` option to the burndown command to send the plotted
  burndown chart to the first card of the `Done` column.
- Add documentation for all CLI commands. Fixes #83.
- Allow to use `move-backlog` without waterline and seabed cards.
  Closes #106 and #107.
- Run `burndown` on `cleanup-sprint`. Fixes #68.