### PR TITLE
Prepare version 0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Master (unreleased)
 
 
-## Version 0.0.13
+## Version 0.0.14
 
 * Add a new `plot-to-board` option to the burndown command to send the plotted
   burndown chart to the first card of the `Done` column.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module Trollolo
 
-  VERSION = "0.0.13"
+  VERSION = "0.0.14"
 
 end


### PR DESCRIPTION
There was a problem when uploading Trollolo 0.0.13 and repushing doesn't work. From [Rubygems docu](http://help.rubygems.org/kb/gemcutter/removing-a-published-rubygem):

> You're not going to run out of gem versions, just push a new one.