### PR TITLE
Fix burndown --plot-to-board -o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* Fix `plot-to-board` option in the burndown command when it is used together
+  with `-o`.
 
 ## Version 0.0.14
 

--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -213,7 +213,9 @@ class BurndownChart
     if options[:plot_to_board]
       trello = TrelloWrapper.new(@settings)
       board = trello.board(board_id)
-      trello.add_attachment(board.burndown_card_id, "burndown-#{sprint.to_s.rjust(2, '0')}.png")
+      name = options['output'] ? options['output'] : '.'
+      name += "/burndown-#{sprint.to_s.rjust(2, '0')}.png"
+      trello.add_attachment(board.burndown_card_id, name)
     end
   end
 


### PR DESCRIPTION
When running `trollolo burndown` with `--plot-to-board` and `-o` options the command failed as it didn't look for the image to upload in the correct directory. :bowtie: 