### PR TITLE
Update README.md to new python naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ You can install Trollolo as gem with `gem install trollolo`.
 For the chart generation you will need a working matplotlib installation and
 the python module to read YAML. On openSUSE you can get that with
 
+    zypper install python2-matplotlib python2-matplotlib-tk python2-PyYAML
+or
+
     zypper install python-matplotlib python-matplotlib-tk python-PyYAML
 
 ## Configuration


### PR DESCRIPTION
python 2 packages are now called `python2-*` instead of `python-*`. This change is needed to install the dependencies for plotting the burndown chart.