### PR TITLE
Enforce that plot-to-board sets chart as cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fix `plot-to-board` option in the burndown command when it is used together
   with `-o`.
+* `burndown --plot-to-board` always sets the burndown chart as the cover.
+  Fix #114.
 
 ## Version 0.0.14
 

--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -215,7 +215,9 @@ class BurndownChart
       board = trello.board(board_id)
       name = options['output'] ? options['output'] : '.'
       name += "/burndown-#{sprint.to_s.rjust(2, '0')}.png"
-      trello.add_attachment(board.burndown_card_id, name)
+      card_id = board.burndown_card_id
+      trello.add_attachment(card_id, name)
+      trello.make_cover(card_id, name)
     end
   end
 


### PR DESCRIPTION
`trollolo burndown --plot-to-board` only  added the new chart to
the card as an attachment. Trello does not always set the new 
attachment as the cover. This ensures that the attachment is added as a cover.
Fix https://github.com/openSUSE/trollolo/issues/114.

I could not test this code: The tests are broken (failing with current release) 
and I also could not find a test for `trollolo burndown --plot-to-board` to extend.
The change in code is very simple though, just calling one additional "Trello" method.