### PR TITLE
Allow to create an Sprint with a custom number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   with `-o`.
 * `burndown --plot-to-board` always sets the burndown chart as the cover.
   Fix #114.
+* Allow to create and update an Sprint with a custom number. Fix #78.
 
 ## Version 0.0.14
 

--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -180,8 +180,9 @@ class BurndownChart
     last_sprint
   end
 
-  def load_last_sprint(burndown_dir)
-    self.sprint = last_sprint(burndown_dir)
+  # It loads the sprint for the given number or the last one if it is nil
+  def load_sprint(burndown_dir, number = nil)
+    self.sprint = number || last_sprint(burndown_dir)
     burndown_data_path = File.join(burndown_dir, burndown_data_filename)
     begin
       read_data burndown_data_path
@@ -192,7 +193,7 @@ class BurndownChart
   end
 
   def update(options)
-    burndown_data_path = load_last_sprint(options['output'] || Dir.pwd)
+    burndown_data_path = load_sprint(options['output'] || Dir.pwd, options[:sprint_number])
 
     burndown_data = BurndownData.new(@settings)
     burndown_data.board_id = board_id
@@ -222,8 +223,8 @@ class BurndownChart
   end
 
   def create_next_sprint(burndown_dir, options = {})
-    load_last_sprint(burndown_dir)
-    self.sprint = self.sprint + 1
+    load_sprint(burndown_dir)
+    self.sprint = options[:sprint_number] || (self.sprint + 1)
     @data["meta"]["total_days"] = options[:total_days] if options[:total_days]
     @data["meta"]["weekend_lines"] = options[:weekend_lines] unless options[:weekend_lines].blank?
     @data["days"] = []

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -167,6 +167,7 @@ EOT
   desc "burndown", "Update burndown chart"
   option :output, :aliases => :o, :desc => "Output directory", :required => false
   option :new_sprint, :aliases => :n, :desc => "Create new sprint"
+  option :sprint_number, type: :numeric, :desc => "Provide the number of the sprint"
   option :total_days, type: :numeric, desc: "Provide how many days the sprint longs. 10 days by default"
   option :weekend_lines, type: :array, desc: "Set the weekend_lines. [3.5, 8.5] by default"
   option :plot, :type => :boolean, :desc => "also plot the new data"
@@ -181,7 +182,7 @@ EOT
     chart = BurndownChart.new @@settings
     begin
       if options[:new_sprint]
-        chart.create_next_sprint(options[:output] || Dir.pwd, { total_days: options[:total_days], weekend_lines: options[:weekend_lines] })
+        chart.create_next_sprint(options[:output] || Dir.pwd, options)
       end
       chart.update(options)
       puts "Updated data for sprint #{chart.sprint}"

--- a/spec/unit/burndown_chart_spec.rb
+++ b/spec/unit/burndown_chart_spec.rb
@@ -367,11 +367,11 @@ EOT
       end
     end
 
-    describe "load_last_sprint" do
+    describe "load_sprint" do
       let(:path) { given_directory_from_data("burndown_dir") }
 
       it "loads the burndown from the 2nd sprint into data" do
-        @chart.load_last_sprint(path)
+        @chart.load_sprint(path)
         expect(@chart.data).to eq(
           { "meta" =>
             { "board_id" => "53186e8391ef8671265eba9d",
@@ -402,7 +402,7 @@ EOT
       end
 
       it "returns the path of the last sprint" do
-        expect(@chart.load_last_sprint(path)).to eq(File.join(path, "burndown-data-02.yaml"))
+        expect(@chart.load_sprint(path)).to eq(File.join(path, "burndown-data-02.yaml"))
       end
     end
 


### PR DESCRIPTION
It should be possible to provide a custom number number for creating a
sprint. As we are currently always updating the sprint with higher
number that also means that we need to be able to modify the sprint for
a concrete Sprint. So, I had implemented a new option `sprint-number`
which can be used for both cases.

Closes https://github.com/openSUSE/trollolo/issues/78

This also contributes to https://github.com/openSUSE/trollolo/issues/76