### PR TITLE
Prepare version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master (unreleased)
 
+
+## Version 0.1.0
+
 * Fix `plot-to-board` option in the burndown command when it is used together
   with `-o`.
 * `burndown --plot-to-board` always sets the burndown chart as the cover.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module Trollolo
 
-  VERSION = "0.0.14"
+  VERSION = "0.1.0"
 
 end


### PR DESCRIPTION
Changes from 0.0.14:

* Fix `plot-to-board` option in the burndown command when it is used together
  with `-o`.
* `burndown --plot-to-board` always sets the burndown chart as the cover.
  Fix #114.
* Allow to create and update an Sprint with a custom number. Fix #78.