### PR TITLE
Fix setting char as cover in plot-to-board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master (unreleased)
 
+* Fix the bug introduced whith always setting the burndown chart as the cover
+  for `burndown --plot-to-board`, as it only worked with files in the current
+  directory.
 
 ## Version 0.1.0
 

--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -218,7 +218,7 @@ class BurndownChart
       name += "/burndown-#{sprint.to_s.rjust(2, '0')}.png"
       card_id = board.burndown_card_id
       trello.add_attachment(card_id, name)
-      trello.make_cover(card_id, name)
+      trello.make_cover(card_id, "burndown-#{sprint.to_s.rjust(2, '0')}.png")
     end
   end
 


### PR DESCRIPTION
This improvement was introduced in https://github.com/openSUSE/trollolo/pull/116, but it was only working on the case that the file was in the current directory. When the route is different it is not working as the name in the card doesn't include the path.