### PR TITLE
Prepare version 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master (unreleased)
 
+
+## Version 0.1.1
+
 * Fix the bug introduced whith always setting the burndown chart as the cover
   for `burndown --plot-to-board`, as it only worked with files in the current
   directory.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module Trollolo
 
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 
 end


### PR DESCRIPTION
* Fix the bug introduced whith always setting the burndown chart as the cover
  for `burndown --plot-to-board`, as it only worked with files in the current
  directory.