### PR TITLE
Add default path to burndown-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* `burndown-init` only requires the `--board-id` option. The `--output` option
+  is optional and defaults to the current working directory. Fix #103.
 
 ## Version 0.1.1
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -153,7 +153,7 @@ EOT
   end
 
   desc "burndown-init", "Initialize burndown chart"
-  option :output, :aliases => :o, :desc => "Output directory", :required => true
+  option :output, :aliases => :o, :desc => "Output directory", :required => false
   option "board-id", :desc => "Id of Trello board", :required => true
   def burndown_init command = nil
     process_global_options options
@@ -161,7 +161,7 @@ EOT
 
     chart = BurndownChart.new @@settings
     puts "Preparing directory..."
-    chart.setup(options[:output], board_id(options["board-id"]))
+    chart.setup(options[:output] || Dir.pwd, board_id(options["board-id"]))
   end
 
   desc "burndown", "Update burndown chart"


### PR DESCRIPTION
`burndown-init` does not require `--output` anymore but instead
defaults to the current working directory.

Fix https://github.com/openSUSE/trollolo/issues/103.