### PR TITLE
add --board-id to trollolo burndown

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,8 @@ Metrics/LineLength:
 # TODO: Down it to 30, 3 times more than Rubocop default
 Metrics/MethodLength:
   Max: 35
+  Exclude:
+    - 'spec/unit/support/webmocks.rb'
 
 Metrics/PerceivedComplexity:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   is optional and defaults to the current working directory. Fix #103.
 * Allow to define checklists that should not be parsed as task lists. Such lists
   can be added in the trollolorc as `no_task_checklists`.
+* Allow to provide a board id when calling `burndown`. Fix #100.
 
 ## Version 0.1.1
 

--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -195,6 +195,7 @@ class BurndownChart
   def update(options)
     burndown_data_path = load_sprint(options['output'] || Dir.pwd, options[:sprint_number])
 
+    @data['meta']['board_id'] = options['board-id'] if options.has_key?('board-id')
     burndown_data = BurndownData.new(@settings)
     burndown_data.board_id = board_id
     burndown_data.fetch

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -175,6 +175,7 @@ EOT
   option 'with-fast-lane', desc: 'Plot Fast Lane with new cards bars', required: false, type: :boolean
   option 'no-tasks', desc: 'Do not plot tasks line', required: false, type: :boolean
   option 'push-to-api', desc: 'Push collected data to api endpoint (in json)', required: false
+  option 'board-id', desc: 'Id of Trello Board'
   def burndown
     process_global_options options
     require_trello_credentials

--- a/spec/unit/burndown_chart_spec.rb
+++ b/spec/unit/burndown_chart_spec.rb
@@ -408,7 +408,7 @@ EOT
 
     describe 'update' do
       let(:path) { given_directory_from_data('burndown_dir') }
-      let(:options) { {'output' => path} }
+      let(:options) { {'output' => path, 'board-id' => '7Zar7bNm'} }
       let(:before) { BurndownChart.new(@settings) }
       let(:after) { BurndownChart.new(@settings) }
 
@@ -432,6 +432,11 @@ EOT
         @chart.update(options)
         after.read_data(File.join(path, 'burndown-data-02.yaml'))
         expect(after.days.size).to eq before.days.size + 1
+      end
+
+      it 'uses provided board-id' do
+        @chart.update(options)
+        expect(@chart.board_id).to eq '7Zar7bNm'
       end
     end
 

--- a/spec/unit/support/webmocks.rb
+++ b/spec/unit/support/webmocks.rb
@@ -28,6 +28,15 @@ def webmock_mapping
         'card_checklists' => 'all'
       },
       file: 'full-board-with-accepted.json'
+    },
+    {
+      path: 'boards/7Zar7bNm',
+      parameters: {
+        'cards' => 'open',
+        'lists' => 'open',
+        'card_checklists' => 'all'
+      },
+      file: 'full-board.json'
     }
   ]
 end


### PR DESCRIPTION
Add `trollolo burndown --board-id` to override previous `board id`
in the `burndown-*.yaml`. The given `board id` is saved in the updated
`burndown-*.yaml`.

I had to run `rubocop --auto-gen-config` to exclude `Metrics/MethodLength` and `Metrics/BlockLength`
after adding tests and webmock data. I made sure that rubocop had nothing else to complain about first.

Fix https://github.com/openSUSE/trollolo/issues/100.