### PR TITLE
Require ruby to be >= 2.2.0 and < 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (unreleased)
 
+* Require Ruby to be >= 2.2.0 and < 2.4.2 until #139 is fixed.
 * `burndown-init` only requires the `--board-id` option. The `--output` option
   is optional and defaults to the current working directory. Fix #103.
 * Allow to define checklists that should not be parsed as task lists. Such lists

--- a/trollolo.gemspec
+++ b/trollolo.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Trello command line client'
   s.description = 'Trollolo is a command line tool to access Trello and support tasks like generation of burndown charts.'
 
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = ['>= 2.2.0', '< 2.4.2']
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'trollolo'
 


### PR DESCRIPTION
until https://github.com/openSUSE/trollolo/issues/139 is fixed.