### PR TITLE
Trollolo 0 2 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master (unreleased)
 
+
+## Version 0.2.0
+
 * Require Ruby to be >= 2.2.0 and < 2.4.2 until #139 is fixed.
 * `burndown-init` only requires the `--board-id` option. The `--output` option
   is optional and defaults to the current working directory. Fix #103.
@@ -9,7 +12,6 @@
   can be added in the trollolorc as `no_task_checklists`.
 * Allow to provide a board id when calling `burndown`. Fix #100.
 * Set the attached image as cover in `burndown --plot-to-board`. Fix #124.
-
 
 ## Version 0.1.1
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module Trollolo
 
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.2.0'.freeze
 
 end

--- a/trollolo.gemspec
+++ b/trollolo.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/version', __FILE__)
 Gem::Specification.new do |s|
   s.name        = 'trollolo'
   s.version     = Trollolo::VERSION
-  s.license     = 'GPL-3'
+  s.license     = 'GPL-3.0'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Cornelius Schumacher']
   s.email       = ['cschum@suse.de']


### PR DESCRIPTION
Changes for 0.2.0:

* Require Ruby to be >= 2.2.0 and < 2.4.2 until #139 is fixed.
* `burndown-init` only requires the `--board-id` option. The `--output` option is optional and defaults to the current working directory. Fix #103.
* Allow to define checklists that should not be parsed as task lists. Such lists can be added in the trollolorc as `no_task_checklists`.
* Allow to provide a board id when calling `burndown`. Fix #100.
* Set the attached image as cover in `burndown --plot-to-board`. Fix #124.

I also corrected the license in the gemspec. :bowtie: 