### PR TITLE
Adds 'in the last sprint' label during cleanup-sprint

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -349,13 +349,14 @@ EOT
 EOT
   option 'board-id', desc: 'Id of the board', required: true
   option 'target-board-id', desc: 'Id of the target board', required: true
+  option 'set-last-sprint-label', desc: 'Set true to label cards as - in the last sprint', required: false, type: :boolean, default: false
   def cleanup_sprint
     process_global_options options
     require_trello_credentials
 
     s = Scrum::SprintCleaner.new(@@settings)
     s.cleanup(board_id(options['board-id']),
-              board_id(options['target-board-id']))
+              board_id(options['target-board-id']), options['set-last-sprint-label'])
   end
 
   desc 'move-backlog', 'Move the planning backlog to the sprint board'

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -72,7 +72,8 @@ class Settings
       },
       'label_names' => {
         'sticky' => 'Sticky',
-        'waterline' => 'Under waterline'
+        'waterline' => 'Under waterline',
+        'in_last_sprint' => 'In last sprint'
       },
       'list_names' => {
         'sprint_backlog' => 'Sprint Backlog',

--- a/spec/unit/scrum/sprint_cleaner_spec.rb
+++ b/spec/unit/scrum/sprint_cleaner_spec.rb
@@ -7,9 +7,19 @@ describe Scrum::SprintCleaner do
     expect(subject).to be
   end
 
-  it 'moves remaining cards to target board', vcr: 'sprint_cleanup', vcr_record: false do
-    expect(STDOUT).to receive(:puts).exactly(13).times
-    expect(subject.cleanup('7Zar7bNm', '72tOJsGS')).to be
+  context 'given set-last-sprint-label flag is true' do
+    before do
+      allow(Trello::Label).to receive(:create)
+      allow_any_instance_of(Trello::Card).to receive(:add_label)
+    end
+
+    it 'moves remaining cards to target board', vcr: 'sprint_cleanup', vcr_record: false do
+      expect(STDOUT).to receive(:puts).exactly(13).times
+      expect(subject.cleanup('7Zar7bNm', '72tOJsGS', set_last_sprint_label: true)).to be
+      subject.sprint_board('7Zar7bNm').backlog_list.cards.each do |card|
+        expect(card).to receive(:add_label).once
+      end
+    end
   end
 
   context 'given correct burndown-data-xx.yaml' do


### PR DESCRIPTION
- Adds 'labelled' option in file cli.rb with default value of False
- Adds add_in_last_sprint_label method to add the required label to the moved card if labelled=True

Hey, @Ana06 this is my initial attempt at resolving #138 , What all I figured out: 
- Trollolo uses [thor] (https://github.com/erikhuda/thor/) to manage the cli interface, I added the labelled option to the cleanup_sprint function in cli.rb
- The variable, along with other arguments, is passed to cleanup method located in scrum/sprint_cleaner.rb
- I defined a add_in_last_sprint_label method to perform the addition of label and called it in move_cards if labelled is 'True'
- I referred [ruby-trello]documentation(http://www.rubydoc.info/gems/ruby-trello/Trello/Card#add_label-instance_method) to find out about the add_label method

I ran the test - `bundle exec rspec spec/unit/scrum/sprint_cleaner_spec.rb` and it threw me the following error, 

```
 ArgumentError:
       wrong number of arguments (given 2, expected 3)
     # ./lib/scrum/sprint_cleaner.rb:5:in `cleanup'
```

I did add the new option 'labelled' in cleanup_sprint in cli.rb, i've added a defualt as 'False' for it too, in the sprint_cleaner_spec file, only two arguments have been passed to test the cleanup function, shouldn't the default value of labelled reach in that case? I'm unable to understand why, Am i missing something? :thinking:  
Could I also get some help on how labels are managed in trollolo? how could i add a new one along with the others? the way i'm adding the label right now is incorrect. 