### PR TITLE
Remove redundant gem --version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 before_install:
-  - gem --version
   - gem list bundler
 rvm:
   - "2.2.3"


### PR DESCRIPTION
`gem --version` is automatically shown, so there is no need to duplicate it.

![image](https://user-images.githubusercontent.com/16052290/36063807-f99b506e-0e81-11e8-9236-ec9e9e0306ad.png)
