### PR TITLE
Remove Master (unreleased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Trollolo Changelog
 
-## Master (unreleased)
-
-
 ## Version 0.2.0
 
 * Require Ruby to be >= 2.2.0 and < 2.4.2 until #139 is fixed.


### PR DESCRIPTION
Remove the he _Master (unreleased)_ part of the [CHANGELOG](https://github.com/openSUSE/trollolo/blob/master/CHANGELOG.md), as discussed in https://github.com/openSUSE/trollolo/pull/163