### PR TITLE
Added --plot-to-board to plot command

### DIFF
--- a/lib/burndown_chart.rb
+++ b/lib/burndown_chart.rb
@@ -167,6 +167,7 @@ class BurndownChart
         cli_switches << '--no-tasks'                 if hash['no-tasks']
         cli_switches << '--with-fast-lane'           if hash['with-fast-lane']
         cli_switches << "--output #{hash['output']}" if hash['output']
+        cli_switches << '--plot-to-board'            if hash['plot-to-board']
         cli_switches << '--verbose'                  if hash['verbose']
       end
     end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -193,6 +193,7 @@ EOT
   option :output, aliases: :o, desc: 'Output directory', required: false
   option 'with-fast-lane', desc: 'Plot Fast Lane with new cards bars', required: false, type: :boolean
   option 'no-tasks', desc: 'Do not plot tasks line', required: false, type: :boolean
+  option 'plot-to-board', desc: 'Send the plotted chart to the first card of the Done column', required: false
   def plot(sprint_number)
     process_global_options options
     BurndownChart.plot(sprint_number, options)

--- a/scripts/create_burndown.py
+++ b/scripts/create_burndown.py
@@ -30,6 +30,7 @@ def parseCommandLine():
   parser.add_argument('--with-fast-lane', action='store_true', help='Draw line for Fast Lane cards', default=False)
   parser.add_argument('--verbose', action='store_true', help='Verbose Output', default=False)
   parser.add_argument('--no-head', action='store_true', help='Run in headless mode', default=False)
+  parser.add_argument('--plot-to-board', help='Send the plotted chart to first card of Done column')
   args = parser.parse_args()
 
   if args.output:


### PR DESCRIPTION
This flag (--plot-to-board) of plot command will send the plotted burndown chart (the very recent) to the first
card of the `Done` column.

close #134