### PR TITLE
Fix Trollolo executable

### DIFF
--- a/trollolo.gemspec
+++ b/trollolo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'ruby-trello', '~> 2.0'
 
   s.files        = `git ls-files`.split("\n")
-  s.executables  = `git ls-files`.split("\n").map{|f| f =~ %r{/^bin\/(.*)/} ? Regexp.last_match(1) : nil}.compact
+  s.executables  = `git ls-files`.split("\n").map{|f| f =~ %r{^bin/(.*)} ? Regexp.last_match(1) : nil}.compact
   s.require_path = 'lib'
 
   s.files += Dir['man/*.?']              # UNIX man pages


### PR DESCRIPTION
Trollolo executable got broken in: https://github.com/openSUSE/trollolo/pull/170

Fixes https://github.com/openSUSE/trollolo/issues/181