### PR TITLE
Changed done_column_name_regex to done_columns

### DIFF
--- a/lib/scrum_board.rb
+++ b/lib/scrum_board.rb
@@ -25,11 +25,12 @@ class ScrumBoard
   end
 
   def done_column
-    done_columns = columns.select{|c| c.name =~ @settings.done_column_name_regex }
+    done_column_name_regex = Regexp.new(@settings.done_columns.join("|"))
+    done_columns = columns.select{|c| c.name =~ done_column_name_regex }
     if done_columns.empty?
       raise DoneColumnNotFoundError, "can't find done column by name regex #{@settings.done_column_name_regex}"
     else
-      done_columns.max_by{|c| c.name.match(@settings.done_column_name_regex).captures.first.to_i }
+      done_columns.max_by{|c| c.name.match(done_column_name_regex).captures.first.to_i }
     end
   end
 

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -20,7 +20,7 @@ class Settings
   attr_accessor :developer_public_key, :member_token, :board_aliases, :verbose,
                 :raw, :not_done_columns, :todo_columns, :doing_columns, :accepted_column_name_regex,
                 :done_column_name_regex, :todo_column_name_regex, :scrum,
-                :no_task_checklists, :swimlanes
+                :no_task_checklists, :swimlanes, :done_columns
 
   def initialize(config_file_path)
     @config_file_path = config_file_path
@@ -36,7 +36,7 @@ class Settings
         @no_task_checklists         = @config['no_task_checklists'].freeze || ['Feedback']
         @todo_columns               = @config['todo_columns'].freeze || ['Sprint Backlog']
         @doing_columns              = @config['doing_columns'].freeze || ['Doing']
-        @done_column_name_regex     = @config['done_column_name_regex'].freeze || /\ADone/
+        @done_columns               = @config['done_columns'].freeze || ['Done']
         @accepted_column_name_regex = @config['accepted_column_name_regex'].freeze || /\AAccepted/
         @todo_column_name_regex     = @config['todo_column_name_regex'].freeze || /\ATo Do\Z/
         @swimlanes                  = @config['swimlanes'].freeze || []


### PR DESCRIPTION
Fixes #189 
Currently user have to write regex expression in .trollolorc file and even after writing regex expression done_column_name_regex was coming as an array of string but we need regex expression there so here array is converted into regex expression on the spot this also allows to write done_columns easily in the .trollolorc file