### PR TITLE
Backup Diff: Adding show-diff command (WIP)

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -10,11 +10,11 @@ class Backup
   end
 
   def backup(board_id)
-    backup_path = File.join(@directory, board_id)
+    backup_path = File.join(@directory, board_id, Time.now.to_i.to_s)
+
     FileUtils.mkdir_p(backup_path)
 
     trello = TrelloWrapper.new(@settings)
-
     data = trello.backup(board_id)
 
     File.open(File.join(backup_path, 'board.json'), 'w') do |f|
@@ -23,13 +23,41 @@ class Backup
   end
 
   def list
-    Dir.entries(@directory).reject { |d| d =~ /^\./ }
+    backups = {}
+    Dir.foreach(@directory) do |sub_dir|
+      unless sub_dir =~ /^\./
+        sub_dir_path = File.join(@directory, sub_dir)
+        backups[sub_dir] = Dir.entries(sub_dir_path).reject { |d| d =~ /^\./ }
+      end
+    end
+
+    backups
   end
 
-  def show(board_id, options = {})
+  def show_diff(board_id, version, optional_version)
+    if optional_version.nil?
+      trello = TrelloWrapper.new(@settings)
+      board_online = trello.retrieve_board_data(board_id)
+
+      backup_path = File.join(@directory, board_id, version, 'board.json')
+      board_backup = JSON.parse(File.read(backup_path))
+
+      JsonDiff.diff(board_backup, board_online)
+    else
+      backup_path = File.join(@directory, board_id, version, 'board.json')
+      board_backup = JSON.parse(File.read(backup_path))
+
+      second_backup_path = File.join(@directory, board_id, optional_version, 'board.json')
+      board_second_backup = JSON.parse(File.read(second_backup_path))
+
+      JsonDiff.diff(board_backup, board_second_backup)
+    end
+  end
+
+  def show(board_id, version, options = {})
     out = options[:output] || STDOUT
 
-    backup_path = File.join(@directory, board_id)
+    backup_path = File.join(@directory, board_id, version)
 
     board = JSON.parse(File.read(File.join(backup_path, 'board.json')))
 

--- a/lib/cli/backup.rb
+++ b/lib/cli/backup.rb
@@ -20,9 +20,10 @@ class CliBackup < Thor
 
   desc 'show', 'Show backup of board'
   option 'board-id', desc: 'Id of Trello board', required: true
+  option 'board-version', desc: 'Version of Trello board', required: true
   option 'show-descriptions', desc: 'Show descriptions of cards', required: false, type: :boolean
   def show
-    Backup.new(CliSettings.settings).show(CliSettings.board_id(options['board-id']), options)
+    Backup.new(CliSettings.settings).show(CliSettings.board_id(options['board-id']), options['board-version'], options)
   end
 
   desc 'show-diff', 'Show diff backup of board from online'

--- a/lib/cli/backup.rb
+++ b/lib/cli/backup.rb
@@ -24,4 +24,15 @@ class CliBackup < Thor
   def show
     Backup.new(CliSettings.settings).show(CliSettings.board_id(options['board-id']), options)
   end
+
+  desc 'show-diff', 'Show diff backup of board from online'
+  option 'board-id', desc: 'Id of Trello board', required: true
+  option 'board-version', desc: 'Version of Trello board', required: true
+  option 'second-board-version', desc: 'Second Local Version of Trello board'
+  def show_diff
+    backup = Backup.new(CliSettings.settings)
+    output_diff = backup.show_diff(CliSettings.board_id(options['board-id']), options['board-version'], options['second-board-version'])
+
+    pp output_diff
+  end
 end

--- a/lib/trollolo.rb
+++ b/lib/trollolo.rb
@@ -17,8 +17,10 @@
 
 require 'thor'
 require 'json'
+require 'json-diff'
 require 'yaml'
 require 'erb'
+require 'pp'
 
 require_relative 'array'
 require_relative 'version'

--- a/spec/unit/backup_spec.rb
+++ b/spec/unit/backup_spec.rb
@@ -19,21 +19,25 @@ describe Backup do
     end
 
     it 'backups board' do
+      version = Time.now.to_i.to_s
       @backup.backup('53186e8391ef8671265eba9d')
-      backup_file = File.join(@directory, '53186e8391ef8671265eba9d', 'board.json')
+      backup_file = File.join(@directory, '53186e8391ef8671265eba9d', version, 'board.json')
       expect(File.exist?(backup_file)).to be true
       expect(File.read(backup_file)).to eq load_test_file('full-board.json').chomp
     end
 
     it 'lists backups' do
+      version = Time.now.to_i.to_s
       @backup.backup('53186e8391ef8671265eba9d')
-      expect(@backup.list).to eq ['53186e8391ef8671265eba9d']
+      expected_output = { '53186e8391ef8671265eba9d' => [version] }
+      expect(@backup.list).to eq expected_output
     end
 
     it 'shows backup' do
       output_capturer = StringIO.new
+      version = Time.now.to_i.to_s
       @backup.backup('53186e8391ef8671265eba9d')
-      @backup.show('53186e8391ef8671265eba9d', output: output_capturer )
+      @backup.show('53186e8391ef8671265eba9d', version, output: output_capturer )
       expect(output_capturer.string).to eq(<<EOT
 Trollolo Testing Board
   Sprint Backlog

--- a/trollolo.gemspec
+++ b/trollolo.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'thor', '~> 0.19'
   s.add_dependency 'ruby-trello', '~> 2.0'
   s.add_dependency 'activemodel', '~> 5.1.5'
+  s.add_dependency 'json-diff', '~> 0.4.1'
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ %r{^bin/(.*)} ? Regexp.last_match(1) : nil}.compact


### PR DESCRIPTION
Hello @Ana06 @cornelius 

On this PR that is a WIP I used [json-diff](https://github.com/espadrine/json-diff)  to diff the backup
from the online version. To do that I created a command on Cli.rb and created a method on Backup.rb to show the backup as json. 

Is this what you were expecting or a custom algorithm of diffing?

After the diff the operations array I need to parse and generate a set of requests to the trello api to do the restore command. Maybe the Diff should be more user friendly and then only use a private version of the diff to the restore command.

Appreciate any suggestions and improvements.
