### PR TITLE
fix(sprint_cleaner): fixes default arguments of the sprint cleaner

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -358,9 +358,8 @@ EOT
   def cleanup_sprint
     process_global_options options
     require_trello_credentials
-
     boards = Scrum::Boards.new(@@settings.scrum)
-    s = Scrum::SprintCleaner.new(@@setting)
+    s = Scrum::SprintCleaner.new(@@settings)
     s.setup_boards(
       planning_board: boards.planning_board(board_from_id(options['board-id'])),
       target_board: board_from_id(options['target-board-id'])

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -365,7 +365,7 @@ EOT
       planning_board: boards.planning_board(board_from_id(options['board-id'])),
       target_board: board_from_id(options['target-board-id'])
     )
-    s.cleanup(options['set-last-sprint-label'])
+    s.cleanup(set_last_sprint_label: options['set-last-sprint-label'])
   end
 
   desc 'move-backlog', 'Move the planning backlog to the sprint board'

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -253,4 +253,13 @@ EOT
       expect(@cli.send(:board_id, 'MyTrelloBoard')).to eq('53186e8391ef8671265eba9d')
     end
   end
+
+  context 'sprint cleanup' do
+    it 'should not return ArgumentError' do
+      @cli.options = {'board-id' => '1234', 'target-board-id' => '123'}
+      expect do
+        @cli.cleanup_sprint
+      end.not_to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -254,12 +254,26 @@ EOT
     end
   end
 
-  context 'sprint cleanup' do
-    it 'should not return ArgumentError' do
-      @cli.options = {'board-id' => '1234', 'target-board-id' => '123'}
+  context 'sprint cleanup', :focus do
+    let(:planning_board) { double('planning-board', id: 1) }
+    let(:target_board) { double('target-board', id: 2) }
+    let(:backlog_list) { double('backlog-list', name: 'Backlog', cards: [card1, card2]) }
+    let(:card1) { double('card', name: '(7) Outra coisa a fazer') }
+    let(:card2) { double('card', name: '(3) Fazer outra coisa') }
+
+    before do
+      allow(Trello::Board).to receive(:find).with('neUHHzDo').and_return(target_board)
+      allow(Trello::Board).to receive(:find).with('P4kJA4bE').and_return(planning_board)
+      allow(planning_board).to receive(:lists).and_return([backlog_list])
+      expect_any_instance_of(Scrum::SprintCleaner).to receive(:cleanup).with(set_last_sprint_label: false)
+    end
+
+    it 'should not raise error' do
+      full_board_mock
+      @cli.options = {'board-id' => 'P4kJA4bE', 'target-board-id' => 'neUHHzDo', 'set-last-sprint-label' => false}
       expect do
         @cli.cleanup_sprint
-      end.not_to raise_error(ArgumentError)
+      end.to_not raise_error
     end
   end
 end

--- a/spec/unit/scrum/sprint_cleaner_spec.rb
+++ b/spec/unit/scrum/sprint_cleaner_spec.rb
@@ -65,6 +65,12 @@ describe Scrum::SprintCleaner do
     end
   end
 
+  context 'with named parameter not given', :focus do
+    it 'should raise ArgumentError' do
+      expect { subject.cleanup('7Zar7bNm', '72tOJsGS', true) }.to raise_error(ArgumentError)
+    end
+  end
+
   context 'given correct burndown-data-xx.yaml' do
     before do
       allow_any_instance_of(BurndownChart).to receive(:update)

--- a/spec/unit/scrum/sprint_cleaner_spec.rb
+++ b/spec/unit/scrum/sprint_cleaner_spec.rb
@@ -65,9 +65,9 @@ describe Scrum::SprintCleaner do
     end
   end
 
-  context 'with named parameter not given', :focus do
+  context 'with named parameter not given' do
     it 'should raise ArgumentError' do
-      expect { subject.cleanup('7Zar7bNm', '72tOJsGS', true) }.to raise_error(ArgumentError)
+      expect { subject.cleanup(true) }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
- earlier named arguments were used, moved to using default arguments to
prevent `ArgumentError`
- made the passing of the third argument in `sprint_cleaner_spec` verbose to make sense of its purpose

Fixes #197