### PR TITLE
optional burndown generation on trollolo scrum end-sprint

### DIFF
--- a/lib/cli/scrum.rb
+++ b/lib/cli/scrum.rb
@@ -46,9 +46,11 @@ class CliScrum < Thor
     CliSettings.process_global_options options
     CliSettings.require_trello_credentials
 
-    s = Scrum::SprintCleaner.new(CliSettings.settings)
-    s.cleanup(CliSettings.board_id(options['board-id']),
-              CliSettings.board_id(options['target-board-id']))
+    boards = Scrum::Boards.new(CliSettings.settings.scrum)
+    cleaner = Scrum::SprintCleaner.new(CliSettings.settings)
+    cleaner.setup_boards(sprint_board: boards.sprint_board(CliSettings.board_from_id(options['board-id'])),
+                         target_board: CliSettings.board_from_id(options['target-board-id']))
+    cleaner.cleanup
   end
 
   desc 'start', 'Move the planning backlog to the sprint board'

--- a/lib/cli/scrum.rb
+++ b/lib/cli/scrum.rb
@@ -42,6 +42,7 @@ class CliScrum < Thor
   EOT
   option 'board-id', desc: 'Id of the board', required: true
   option 'target-board-id', desc: 'Id of the target board', required: true
+  option 'burndown-update', desc: 'Generate new burndown data', type: :boolean, default: false
   def end_sprint
     CliSettings.process_global_options options
     CliSettings.require_trello_credentials
@@ -50,7 +51,7 @@ class CliScrum < Thor
     cleaner = Scrum::SprintCleaner.new(CliSettings.settings)
     cleaner.setup_boards(sprint_board: boards.sprint_board(CliSettings.board_from_id(options['board-id'])),
                          target_board: CliSettings.board_from_id(options['target-board-id']))
-    cleaner.cleanup
+    cleaner.cleanup(run_burndown: options['burndown-update'])
   end
 
   desc 'start', 'Move the planning backlog to the sprint board'

--- a/lib/scrum/sprint_cleaner.rb
+++ b/lib/scrum/sprint_cleaner.rb
@@ -2,10 +2,10 @@ module Scrum
   class SprintCleaner < TrelloService
     include BoardLocator
 
-    def cleanup(set_last_sprint_label: false)
+    def cleanup(set_last_sprint_label: false, run_burndown: false)
       load
 
-      gen_burndown
+      gen_burndown if run_burndown
 
       move_cards(@board.backlog_list, set_last_sprint_label)
       move_cards(@board.doing_list, set_last_sprint_label) if @board.doing_list
@@ -64,7 +64,7 @@ module Scrum
       chart = BurndownChart.new(@settings)
       begin
         chart.update({})
-        puts 'New burndown data was generated automatically.'
+        puts "Updated data for sprint #{chart.sprint}"
       rescue TrolloloError => e
         if e.message =~ /(burndown-data-)\d*.yaml' (not found)/
           puts e.message + '. Skipping automatic burndown generation.'

--- a/spec/unit/scrum/sprint_cleaner_spec.rb
+++ b/spec/unit/scrum/sprint_cleaner_spec.rb
@@ -37,7 +37,7 @@ describe Scrum::SprintCleaner do
     end
 
     it 'moves remaining cards to target board' do
-      expect(STDOUT).to receive(:puts).exactly(4).times
+      expect(STDOUT).to receive(:puts).exactly(3).times
       expect(old_story_card).to receive(:move_to_board).with(target_board, ready_for_estimation).exactly(3).times
       expect(old_story_card).to receive(:add_label).exactly(3).times
       sprint_cleaner.cleanup(set_last_sprint_label: true)
@@ -45,7 +45,7 @@ describe Scrum::SprintCleaner do
   end
 
   it 'moves remaining cards to target board' do
-    expect(STDOUT).to receive(:puts).exactly(4).times
+    expect(STDOUT).to receive(:puts).exactly(3).times
     expect(old_story_card).to receive(:move_to_board).with(target_board, ready_for_estimation).exactly(3).times
     sprint_cleaner.cleanup
   end
@@ -70,11 +70,18 @@ describe Scrum::SprintCleaner do
       allow_any_instance_of(BurndownChart).to receive(:update)
     end
 
-    it 'generates new burndown data' do
+    it 'does not generate new burndown data per default' do
       expect(old_story_card).to receive(:move_to_board).with(target_board, ready_for_estimation).exactly(3).times
       expect do
         sprint_cleaner.cleanup
-      end.to output(/^(New burndown data was generated automatically)/).to_stdout
+      end.not_to output(/^(Update data for sprint 1)/).to_stdout
+    end
+
+    it 'generates new burndown data when run_burndown parameter is true' do
+      expect(old_story_card).to receive(:move_to_board).with(target_board, ready_for_estimation).exactly(3).times
+      expect do
+        sprint_cleaner.cleanup(run_burndown: true)
+      end.to output(/^(Update data for sprint 1)*/).to_stdout
     end
   end
 


### PR DESCRIPTION
In the past `trollolo scrum end-sprint` (formerly `trollolo cleanup-sprint`) generated burndown data every time. Now it requires to be explicitly called with a new flag.
This pull request adds a new flag twhich is named after `trollolo burndown update`:
```
trollolo scrum end-sprint --burndown-update
```

To add this new flag, I first had to fix a problem with `trollolo scrum end-sprint` since it did not pass the boards to `Scrum::SprintCleaner`
Fixes #201 

I could not figure out how to test the cli (what to mock, and how) and opened #203 for now.