### PR TITLE
feat(add-last-sprint-label): adds flag to add last sprint label

### DIFF
--- a/lib/cli/scrum.rb
+++ b/lib/cli/scrum.rb
@@ -43,6 +43,7 @@ class CliScrum < Thor
   option 'board-id', desc: 'Id of the board', required: true
   option 'target-board-id', desc: 'Id of the target board', required: true
   option 'burndown-update', desc: 'Generate new burndown data', type: :boolean, default: false
+  option 'set-last-sprint-label', desc: 'Set true to label cards as - in the last sprint', required: false, type: :boolean, default: false
   def end_sprint
     CliSettings.process_global_options options
     CliSettings.require_trello_credentials
@@ -51,7 +52,7 @@ class CliScrum < Thor
     cleaner = Scrum::SprintCleaner.new(CliSettings.settings)
     cleaner.setup_boards(sprint_board: boards.sprint_board(CliSettings.board_from_id(options['board-id'])),
                          target_board: CliSettings.board_from_id(options['target-board-id']))
-    cleaner.cleanup(run_burndown: options['burndown-update'])
+    cleaner.cleanup(set_last_sprint_label: options['set-last-sprint-label'], run_burndown: options['burndown-update'])
   end
 
   desc 'start', 'Move the planning backlog to the sprint board'


### PR DESCRIPTION
* code for cleanup was moved from `cli.rb` to `scrum.rb`, added the option there
* cleanup function in `sprint_cleaner.rb` was still present with the
flag so no changes there