### PR TITLE
Suppress warning `File.exists? is a deprecated name, use File.exist? instead`

### DIFF
--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -24,7 +24,7 @@ class Settings
 
   def initialize(config_file_path)
     @config_file_path = config_file_path
-    if File.exists? config_file_path
+    if File.exist? config_file_path
       @config = YAML.load_file(config_file_path)
 
       if @config


### PR DESCRIPTION
This PR suppresses the following warning at `lib/settings.rb` .

```
ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]

RUBYOPT=-w bundle exec rspec spec/unit
/Users/numata/git/github.com/openSUSE/trollolo/lib/settings.rb:27: warning: File.exists? is a deprecated name, use File.exist? instead
```